### PR TITLE
AP_NavEKF: Fix bug preventing home position being set by copter

### DIFF
--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -3756,7 +3756,9 @@ bool NavEKF::getMagOffsets(Vector3f &magOffsets) const
 }
 
 // Return the last calculated latitude, longitude and height in WGS-84
-// If a calculated location isn't available, return false and the raw GPS measurement or last known position if available
+// If a calculated location isn't available, return a raw GPS measurement
+// The status will return true if a calculation or raw measurement is available
+// The getFilterStatus() function provides a more detailed description of data health and must be checked if data is to be used for flight control
 bool NavEKF::getLLH(struct Location &loc) const
 {
     if(validOrigin) {
@@ -3779,11 +3781,12 @@ bool NavEKF::getLLH(struct Location &loc) const
                 // we have a GPS position fix to return
                 const struct Location &gpsloc = _ahrs->get_gps().location();
                 loc = gpsloc;
+                return true;
             } else {
                 // if no GPS fix, provide last known position before entering the mode
                 location_offset(loc, lastKnownPositionNE.x, lastKnownPositionNE.y);
+                return false;
             }
-            return false;
         }
     } else {
         // If no origin has been defined for the EKF, then we cannot use its position states so return a raw

--- a/libraries/AP_NavEKF/AP_NavEKF.h
+++ b/libraries/AP_NavEKF/AP_NavEKF.h
@@ -154,8 +154,9 @@ public:
     bool getMagOffsets(Vector3f &magOffsets) const;
 
     // Return the last calculated latitude, longitude and height in WGS-84
-    // If a calculated location isn't available, return false and the raw GPS measurement or last known position if available
-    // If false returned, do not use for flight control
+    // If a calculated location isn't available, return a raw GPS measurement
+    // The status will return true if a calculation or raw measurement is available
+    // The getFilterStatus() function provides a more detailed description of data health and must be checked if data is to be used for flight control
     bool getLLH(struct Location &loc) const;
 
     // return the latitude and longitude and height used to set the NED origin


### PR DESCRIPTION
The interface definition has been modified so that it returns true for a position obtained using either the normal inertial navigation calculation, or a raw GPS measurement.
This enables this function to be used to set a home position before flight.
This fixes the bug that was producing a "EKF home variance" pre-arm error message preventing the copter arming in GPS modes regardless of EKF status.
