### PR TITLE
AP_NavEKF: reset velocity on arming

### DIFF
--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -4951,6 +4951,7 @@ void NavEKF::performArmingChecks()
         if (vehicleArmed) {
             // Reset filter position to GPS when transitioning into flight mode
             // We need to do this becasue the vehicle may have moved since the EKF origin was set
+            ResetVelocity();
             ResetPosition();
             StoreStatesReset();
         } else {


### PR DESCRIPTION
This addresses observed bad takeoffs in which the copter leans hard briefly.
