### PR TITLE
AP_Mount: implement a neutral state for the MAVlink Mount

### DIFF
--- a/libraries/AP_Mount/AP_Mount_MAVLink.cpp
+++ b/libraries/AP_Mount/AP_Mount_MAVLink.cpp
@@ -39,6 +39,12 @@ void AP_Mount_MAVLink::update()
 
         // move mount to a neutral position, typically pointing forward
         case MAV_MOUNT_MODE_NEUTRAL:
+            {
+            const Vector3f &target = _state._neutral_angles.get();
+            _angle_ef_target_rad.x = ToRad(target.x);
+            _angle_ef_target_rad.y = ToRad(target.y);
+            _angle_ef_target_rad.z = ToRad(target.z);
+            }
             break;
 
         // point to the angles given by a mavlink message


### PR DESCRIPTION
Implements a neutral position for gimbal mount. This makes it easy for the Artoo or GCS to put the gimbal in a safe position for landing.
