### PR TITLE
AP_NavEKF: Add pre-arm check for horizontal inertial errors

### DIFF
--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -447,8 +447,9 @@ bool NavEKF::healthy(void) const
     if ((imuSampleTime_ms - ekfStartTime_ms) < 1000 ) {
         return false;
     }
-    // barometer innovations must be within limits when on-ground
-    if (!vehicleArmed && (fabsf(innovVelPos[5]) > 1.0f)) {
+    // barometer and position innovations must be within limits when on-ground
+    float horizErrSq = sq(innovVelPos[3]) + sq(innovVelPos[4]);
+    if (!vehicleArmed && (fabsf(innovVelPos[5]) > 1.0f || horizErrSq > 1.0f)) {
         return false;
     }
 


### PR DESCRIPTION
This check will declare the EKF as unhealthy if the horizontal position innovations exceed a threshold  before motors are armed. This will help to prevent a take-off with bad inertial data caused by bad accel or gyro offsets. This reduces the likelihood the type of error that Grant encountered flying a DVT2 in China on 0.2.6 where he was able to  arm and take-off with a bad inertial solution. 
