### PR TITLE
GPS Diagnostic logs

### DIFF
--- a/ArduCopter/ArduCopter.pde
+++ b/ArduCopter/ArduCopter.pde
@@ -1069,6 +1069,11 @@ static void one_hz_loop()
     if (should_log(MASK_LOG_ANY)) {
         Log_Write_Data(DATA_AP_STATE, ap.value);
     }
+    if(should_log(MASK_LOG_GPS)) {
+        for (uint8_t i=0; i<gps.num_sensors(); i++) {
+            DataFlash.Log_Write_GPSdiag(gps, i);
+        }
+    }
 
     // perform pre-arm checks & display failures every 2 seconds
     if (!motors.armed()) {
@@ -1088,7 +1093,6 @@ static void one_hz_loop()
             set_pre_arm_check(pre_arm_checks(false));
         }
     }
-
     gcs_send_message(MSG_ARMMASK);
 
     // auto disarm checks

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -505,6 +505,10 @@ AP_GPS::send_mavlink_gps_raw(mavlink_channel_t chan)
         num_sats(0));
 }
 
+AP_GPS::GPS_Diag AP_GPS::get_gps_diagnostic(uint8_t instance) const
+{
+    return drivers[instance]->get_gps_diagnostic();
+}
 #if GPS_MAX_INSTANCES > 1
 void 
 AP_GPS::send_mavlink_gps2_raw(mavlink_channel_t chan)

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -44,6 +44,7 @@
 #define GPS_RTK_AVAILABLE 0
 #endif
 
+#define SAT_INFO_MAX_SATELLITES 22
 /**
  * save flash by skipping NMEA and SIRF support on ArduCopter on APM1/2 or any frame type on AVR1280 CPUs
  */
@@ -139,6 +140,23 @@ public:
         uint32_t last_gps_time_ms;          ///< the system time we got the last GPS timestamp, milliseconds
     };
 
+    //GPS Diagnostic structure filled by the backend
+    struct GPS_Diag {
+        uint8_t     cnt;
+        uint32_t    ttff;
+        struct {
+            uint8_t		chn; 		/**< Channel number, 255 for SVs not assigned to a channel */
+            uint8_t		svid; 		/**< Satellite ID */
+            uint8_t		flags;
+            uint8_t		quality;
+            uint8_t		cno;		/**< Carrier to Noise Ratio (Signal Strength) [dbHz] */
+            int8_t		elev; 		/**< Elevation [deg] */
+            int16_t		azim; 		/**< Azimuth [deg] */
+            int32_t		prRes; 		/**< Pseudo range residual [cm] */
+        }satellite_info[SAT_INFO_MAX_SATELLITES];
+    };
+    
+    AP_GPS::GPS_Diag get_gps_diagnostic(uint8_t instance) const;
     // Accessor functions
 
     // return number of active GPS sensors. Note that if the first GPS

--- a/libraries/AP_GPS/AP_GPS_UBLOX.h
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.h
@@ -24,7 +24,6 @@
 #define __AP_GPS_UBLOX_H__
 
 #include <AP_GPS.h>
-
 /*
  *  try to put a UBlox into binary mode. This is in two parts. 
  *
@@ -48,7 +47,7 @@ public:
     bool read();
 
     static bool _detect(struct UBLOX_detect_state &state, uint8_t data);
-
+    AP_GPS::GPS_Diag get_gps_diagnostic() { return _diag; }
 private:
     // u-blox UBX protocol essentials
     struct PACKED ubx_header {
@@ -112,6 +111,17 @@ private:
         uint32_t time_to_first_fix;
         uint32_t uptime;                                // milliseconds
     };
+    struct PACKED ubx_nav_sat_info {
+        uint8_t		chn; 		/**< Channel number, 255 for SVs not assigned to a channel */
+        uint8_t		svid; 		/**< Satellite ID */
+        uint8_t		flags;
+        uint8_t		quality;
+        uint8_t		cno;		/**< Carrier to Noise Ratio (Signal Strength) [dbHz] */
+        int8_t		elev; 		/**< Elevation [deg] */
+        int16_t		azim; 		/**< Azimuth [deg] */
+        int32_t		prRes; 		/**< Pseudo range residual [cm] */
+    };
+    
     struct PACKED ubx_nav_solution {
         uint32_t time;
         int32_t time_nsec;
@@ -217,6 +227,10 @@ private:
         ubx_cfg_sbas sbas;
         ubx_nav_svinfo_header svinfo_header;
         ubx_ack_ack ack;
+        struct{
+            ubx_nav_svinfo_header svinfo_header;
+            ubx_nav_sat_info satellite_info[SAT_INFO_MAX_SATELLITES];
+        };
         uint8_t bytes[];
     } _buffer;
 
@@ -289,7 +303,8 @@ private:
 
     // Buffer parse & GPS state update
     bool        _parse_gps();
-
+    ubx_nav_sat_info* _sattelite_info;
+    AP_GPS::GPS_Diag _diag;
     // used to update fix between status and position packets
     AP_GPS::GPS_Status next_fix;
 

--- a/libraries/AP_GPS/AP_GPS_UBLOX.h
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.h
@@ -225,7 +225,6 @@ private:
         ubx_mon_hw_68 mon_hw_68;
         ubx_mon_hw2 mon_hw2;
         ubx_cfg_sbas sbas;
-        ubx_nav_svinfo_header svinfo_header;
         ubx_ack_ack ack;
         struct{
             ubx_nav_svinfo_header svinfo_header;

--- a/libraries/AP_GPS/GPS_Backend.h
+++ b/libraries/AP_GPS/GPS_Backend.h
@@ -38,7 +38,7 @@ public:
     virtual bool read() = 0;
 
     virtual void inject_data(uint8_t *data, uint8_t len) { return; }
-
+    virtual AP_GPS::GPS_Diag get_gps_diagnostic() { AP_GPS::GPS_Diag gpsdiag = {0}; return gpsdiag; } 
 #if GPS_RTK_AVAILABLE
     // Highest status supported by this GPS. 
     // Allows external system to identify type of receiver connected.
@@ -57,7 +57,6 @@ protected:
     AP_HAL::UARTDriver *port;           ///< UART we are attached to
     AP_GPS &gps;                        ///< access to frontend (for parameters)
     AP_GPS::GPS_State &state;           ///< public state for this instance
-
     // common utility functions
     int32_t swap_int32(int32_t v) const;
     int16_t swap_int16(int16_t v) const;

--- a/libraries/DataFlash/DataFlash.h
+++ b/libraries/DataFlash/DataFlash.h
@@ -63,6 +63,7 @@ public:
     void Log_Write_Format(const struct LogStructure *structure);
     void Log_Write_Parameter(const char *name, float value);
     void Log_Write_GPS(const AP_GPS &gps, uint8_t instance, int32_t relative_alt);
+    void Log_Write_GPSdiag(const AP_GPS &gps, uint8_t instance);
     void Log_Write_IMU(const AP_InertialSensor &ins);
     void Log_Write_RCIN(void);
     void Log_Write_RCOUT(void);
@@ -175,6 +176,21 @@ struct PACKED log_GPS {
     float    vel_z;
     uint32_t apm_time;
 };
+
+struct PACKED log_GPSdiag {
+    LOG_PACKET_HEADER;
+    uint32_t timestamp;
+    uint8_t chn; 		/**< Channel number, 255 for SVs not assigned to a channel */
+    uint8_t svid; 		/**< Satellite ID */
+    uint8_t flags;
+    uint8_t quality;
+    uint8_t cno;		/**< Carrier to Noise Ratio (Signal Strength) [dbHz] */
+    int8_t elev; 		/**< Elevation [deg] */
+    int16_t azim; 		/**< Azimuth [deg] */
+    int32_t prRes; 		/**< Pseudo range residual [cm] */
+    uint32_t ttff;
+};
+
 
 struct PACKED log_GPS2 {
     LOG_PACKET_HEADER;
@@ -613,7 +629,9 @@ Format characters in the format string for binary log messages
     { LOG_COMPASS_MSG, sizeof(log_Compass), \
       "MAG", "IhhhhhhhhhB",    "TimeMS,MagX,MagY,MagZ,OfsX,OfsY,OfsZ,MOfsX,MOfsY,MOfsZ,Health" }, \
     { LOG_MODE_MSG, sizeof(log_Mode), \
-      "MODE", "IMB",         "TimeMS,Mode,ModeNum" }
+      "MODE", "IMB",         "TimeMS,Mode,ModeNum" }, \
+    { LOG_GPSDIAG_MSG, sizeof(log_GPSdiag), \
+      "GPSD", "IBBBBBbhiI",   "TimeMS,chn,svid,flags,quality,cno,elev,azim,prRes,ttff"}
 
 // messages for more advanced boards
 #define LOG_EXTRA_STRUCTURES \
@@ -752,7 +770,7 @@ Format characters in the format string for binary log messages
 #define LOG_UACK_MSG      180
 #define LOG_UNAK_MSG      181
 #define LOG_USTG_MSG      182
-
+#define LOG_GPSDIAG_MSG   183
 // message types 200 to 210 reversed for GPS driver use
 // message types 211 to 220 reversed for autotune use
 

--- a/libraries/DataFlash/LogFile.cpp
+++ b/libraries/DataFlash/LogFile.cpp
@@ -708,6 +708,30 @@ void DataFlash_Class::Log_Write_GPS(const AP_GPS &gps, uint8_t i, int32_t relati
 #endif
 }
 
+//Write an GPS Diagnostic Packet
+void DataFlash_Class::Log_Write_GPSdiag(const AP_GPS &gps, uint8_t instance)
+{
+    AP_GPS::GPS_Diag diag;
+
+    diag = gps.get_gps_diagnostic(instance);
+    for(uint8_t cnt=0; cnt<diag.cnt; cnt++){
+        struct log_GPSdiag pkt = {
+            LOG_PACKET_HEADER_INIT(LOG_GPSDIAG_MSG),
+            timestamp   : hal.scheduler->millis(),
+            chn         : diag.satellite_info[cnt].chn,
+            svid        : diag.satellite_info[cnt].svid,
+            flags       : diag.satellite_info[cnt].flags,
+            quality     : diag.satellite_info[cnt].quality,
+            cno         : diag.satellite_info[cnt].cno,
+            elev        : diag.satellite_info[cnt].elev,
+            azim        : diag.satellite_info[cnt].azim,
+            prRes       : diag.satellite_info[cnt].prRes,
+            ttff        : diag.ttff
+        };
+        WriteBlock(&pkt, sizeof(pkt));
+    }
+}
+
 // Write an RCIN packet
 void DataFlash_Class::Log_Write_RCIN(void)
 {


### PR DESCRIPTION
repeated block (numCh times)
chn - Channel number, 255 for SVs not assigned to a
channel
svid - Satellite ID
flags - Bitmask
    1        svUsed SV is used for navigation
    2       diffCorr Differential correction data is available for this SV
    3      orbitAvail Orbit information is available for this SV (Ephemeris or Almanac)
    4      orbitEph Orbit information is Ephemeris
    5      unhealthy SV is unhealthy / shall not be used
    6      orbitAlm Orbit information is Almanac Plus
    7      orbitAop Orbit information is AssistNow Autonomous
    8      smoothed Carrier smoothed pseudorange used

quality - Bitfield
Signal Quality indicator (range 0..7). The following list shows the meaning of the different QI values:
0: This channel is idle
1: Channel is searching
2: Signal aquired
3: Signal detected but unusable
4: Code Lock on Signal
5, 6, 7: Code and Carrier locked


cno dBHz Carrier to Noise Ratio (Signal Strength)
elev deg Elevation in integer degrees
azim deg Azimuth in integer degrees
prRes cm Pseudo range residual in centimetres
ttff ms time to first fix