### PR TITLE
Copter: de-conflict parameter keys

### DIFF
--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -104,7 +104,6 @@ public:
         k_param_gps_hdop_good,              // deprecated - remove
         k_param_battery,
         k_param_fs_batt_mah,
-        k_param_fs_batt_curr_rtl,
         k_param_angle_rate_max,         // remove
         k_param_rssi_range,
         k_param_rc_feel_rp,
@@ -194,7 +193,10 @@ public:
         k_param_ch11_option,
         k_param_ch12_option,     // 123
         k_param_takeoff_trigger_dz,
-        k_param_rtl_speed_cms,
+
+        //solo params 135..139
+        k_param_rtl_speed_cms=135,
+        k_param_fs_batt_curr_rtl,
 
         //
         // 140: Sensor parameters


### PR DESCRIPTION
This corrects the parameter keys. One of them had been added to the middle of a group, pushing everything after it down. That could cause users' parameter tables to become corrupt in the future.
