### PR TITLE
AP_Mount: add option of body locked control loop for the solo gimbal

### DIFF
--- a/libraries/AP_Mount/AP_Gimbal.cpp
+++ b/libraries/AP_Mount/AP_Gimbal.cpp
@@ -18,8 +18,15 @@ void AP_Gimbal::receive_feedback(mavlink_channel_t chan, mavlink_message_t *msg)
 
     decode_feedback(msg);
     update_state();
-    if (_ekf.getStatus() && !isCopterFlipped() && _gimbalParams.K_gimbalRate!=0.0f){
-        send_control(chan);
+    if (_gimbalParams.K_gimbalRate!=0.0f){
+        if (lockedToBody){
+            send_control(chan);
+        }else{
+            if (_ekf.getStatus() && !isCopterFlipped()){
+                send_control(chan); 
+            }
+        }
+        
     }
 
     Quaternion quatEst;_ekf.getQuat(quatEst);Vector3f eulerEst;quatEst.to_euler(eulerEst.x, eulerEst.y, eulerEst.z);
@@ -64,11 +71,16 @@ void AP_Gimbal::update_state()
     _ekf.getQuat(quatEst);
 
     // Add the control rate vectors
-    gimbalRateDemVec.zero();
-    gimbalRateDemVec += getGimbalRateDemVecYaw(quatEst);
-    gimbalRateDemVec += getGimbalRateDemVecTilt(quatEst);
-    gimbalRateDemVec += getGimbalRateDemVecForward(quatEst);
-    gimbalRateDemVec += getGimbalRateDemVecGyroBias();
+    if(lockedToBody){
+        gimbalRateDemVec.zero();
+        gimbalRateDemVec += getGimbalRateBodyLock();    
+    }else{
+        gimbalRateDemVec.zero();
+        gimbalRateDemVec += getGimbalRateDemVecYaw(quatEst);
+        gimbalRateDemVec += getGimbalRateDemVecTilt(quatEst);
+        gimbalRateDemVec += getGimbalRateDemVecForward(quatEst);
+        gimbalRateDemVec += getGimbalRateDemVecGyroBias();   
+    }    
 }
 
 Vector3f AP_Gimbal::getGimbalRateDemVecYaw(const Quaternion &quatEst)
@@ -173,6 +185,38 @@ Vector3f AP_Gimbal::getGimbalRateDemVecGyroBias()
     Vector3f gyroBias;
     _ekf.getGyroBias(gyroBias);
     return gyroBias;
+}
+
+Vector3f AP_Gimbal::getGimbalRateBodyLock()
+{
+        // Define rotation from vehicle to gimbal using a 312 rotation sequence
+        Matrix3f Tvg;
+        float cosPhi = cosf(_measurement.joint_angles.x);
+        float cosTheta = cosf(_measurement.joint_angles.y);
+        float sinPhi = sinf(_measurement.joint_angles.x);
+        float sinTheta = sinf(_measurement.joint_angles.y);
+        float sinPsi = sinf(_measurement.joint_angles.z);
+        float cosPsi = cosf(_measurement.joint_angles.z);
+        Tvg[0][0] = cosTheta*cosPsi-sinPsi*sinPhi*sinTheta;
+        Tvg[1][0] = -sinPsi*cosPhi;
+        Tvg[2][0] = cosPsi*sinTheta+cosTheta*sinPsi*sinPhi;
+        Tvg[0][1] = cosTheta*sinPsi+cosPsi*sinPhi*sinTheta;
+        Tvg[1][1] = cosPsi*cosPhi;
+        Tvg[2][1] = sinPsi*sinTheta-cosTheta*cosPsi*sinPhi;
+        Tvg[0][2] = -sinTheta*cosPhi;
+        Tvg[1][2] = sinPhi;
+        Tvg[2][2] = cosTheta*cosPhi;
+
+        // multiply the joint angles by a gain to calculate a rate vector required to keep the joints centred
+        Vector3f gimbalRateDemVecYaw;
+        gimbalRateDemVecYaw.x = - _gimbalParams.K_gimbalRate * _measurement.joint_angles.x;
+        gimbalRateDemVecYaw.y = - _gimbalParams.K_gimbalRate * _measurement.joint_angles.y;
+        gimbalRateDemVecYaw.z = - _gimbalParams.K_gimbalRate * _measurement.joint_angles.z;
+
+        // Add a feedforward term from vehicle gyros
+        gimbalRateDemVecYaw += Tvg * _ahrs.get_gyro();
+
+        return gimbalRateDemVecYaw;
 }
 
 void AP_Gimbal::send_control(mavlink_channel_t chan)

--- a/libraries/AP_Mount/AP_Gimbal.h
+++ b/libraries/AP_Mount/AP_Gimbal.h
@@ -32,6 +32,7 @@ public:
         _gimbalParams(parameters),
         vehicleYawRateFilt(0.0f),
         yawRateFiltPole(10.0f),
+        lockedToBody(false),
         yawErrorLimit(0.1f)
     {
     }
@@ -54,6 +55,8 @@ public:
 
     Vector3f    gimbalRateDemVec;       // degrees/s
     Vector3f    _angle_ef_target_rad;   // desired earth-frame roll, tilt and pan angles in radians
+
+    bool lockedToBody;
 
 private:
     
@@ -84,6 +87,7 @@ private:
     Vector3f getGimbalRateDemVecTilt(const Quaternion &quatEst);
     Vector3f getGimbalRateDemVecForward(const Quaternion &quatEst);
     Vector3f getGimbalRateDemVecGyroBias();
+    Vector3f getGimbalRateBodyLock();
 
 };
 

--- a/libraries/AP_Mount/AP_Mount_MAVLink.cpp
+++ b/libraries/AP_Mount/AP_Mount_MAVLink.cpp
@@ -35,11 +35,13 @@ void AP_Mount_MAVLink::update()
     switch(get_mode()) {
         // move mount to a "retracted" position.  we do not implement a separate servo based retract mechanism
         case MAV_MOUNT_MODE_RETRACT:
+            _gimbal.lockedToBody = true;
             break;
 
         // move mount to a neutral position, typically pointing forward
         case MAV_MOUNT_MODE_NEUTRAL:
             {
+            _gimbal.lockedToBody = false;
             const Vector3f &target = _state._neutral_angles.get();
             _angle_ef_target_rad.x = ToRad(target.x);
             _angle_ef_target_rad.y = ToRad(target.y);
@@ -49,17 +51,20 @@ void AP_Mount_MAVLink::update()
 
         // point to the angles given by a mavlink message
         case MAV_MOUNT_MODE_MAVLINK_TARGETING:
+            _gimbal.lockedToBody = false;
             // do nothing because earth-frame angle targets (i.e. _angle_ef_target_rad) should have already been set by a MOUNT_CONTROL message from GCS
             break;
 
         // RC radio manual angle control, but with stabilization from the AHRS
         case MAV_MOUNT_MODE_RC_TARGETING:
+            _gimbal.lockedToBody = false;
             // update targets using pilot's rc inputs
             update_targets_from_rc();
             break;
 
         // point mount to a GPS point given by the mission planner
         case MAV_MOUNT_MODE_GPS_POINT:
+            _gimbal.lockedToBody = false;
             if(_frontend._ahrs.get_gps().status() >= AP_GPS::GPS_OK_FIX_2D) {
                 calc_angle_to_location(_state._roi_target, _angle_ef_target_rad, true, true);
             }


### PR DESCRIPTION
This will be used to lock the gimbal to the body frame when doing things like mag cal.

Changing the mount mode to MAV_MOUNT_MODE_RETRACT makes the gimbal enter this different control loop.