### PR TITLE
GCS_MAVLink: revert handling of GIMBAL_REPORT on routing code to default

### DIFF
--- a/libraries/GCS_MAVLink/MAVLink_routing.cpp
+++ b/libraries/GCS_MAVLink/MAVLink_routing.cpp
@@ -468,8 +468,8 @@ void MAVLink_routing::get_targets(const mavlink_message_t* msg, int16_t &sysid, 
         compid = mavlink_msg_v2_extension_get_target_component(msg);
         break;
     case MAVLINK_MSG_ID_GIMBAL_REPORT:
-        sysid  = mavlink_system.sysid;//mavlink_msg_gimbal_report_get_target_system(msg);
-        compid = mavlink_system.compid;//mavlink_msg_gimbal_report_get_target_component(msg);
+        sysid  = mavlink_msg_gimbal_report_get_target_system(msg);
+        compid = mavlink_msg_gimbal_report_get_target_component(msg);
         break;
     case MAVLINK_MSG_ID_GIMBAL_CONTROL:
         sysid  = mavlink_msg_gimbal_control_get_target_system(msg);


### PR DESCRIPTION
As of solo-gimbal version 0.15.2 the gimbal sends a proper GIMBAL_REPORT message so this hack is not required anymore