### PR TITLE
replace "takeoff expected" and "touchdown expected" booleans with enumerated flight_phase type

### DIFF
--- a/ArduCopter/ArduCopter.pde
+++ b/ArduCopter/ArduCopter.pde
@@ -392,7 +392,7 @@ static struct {
     bool touchdown_expected;
     uint32_t takeoff_time_ms;
     float takeoff_alt_cm;
-} gndeffect_state;
+} flight_phase_state;
 
 static RCMapper rcmap;
 
@@ -941,7 +941,7 @@ static void throttle_loop()
     // update throttle_low_comp value (controls priority of throttle vs attitude control)
     update_throttle_thr_mix();
 
-    update_ground_effect_detector();
+    update_ekf_flight_phase();
 
     // check auto_armed status
     update_auto_armed();

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -455,15 +455,5 @@ bool AP_AHRS_NavEKF::getMagOffsets(Vector3f &magOffsets)
     return status;
 }
 
-void AP_AHRS_NavEKF::setTakeoffExpected(bool val)
-{
-    EKF.setTakeoffExpected(val);
-}
-
-void AP_AHRS_NavEKF::setTouchdownExpected(bool val)
-{
-    EKF.setTouchdownExpected(val);
-}
-
 #endif // AP_AHRS_NAVEKF_AVAILABLE
 

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.h
@@ -115,10 +115,6 @@ public:
 
     void set_ekf_use(bool setting);
 
-
-    void setTakeoffExpected(bool val);
-    void setTouchdownExpected(bool val);
-
     float get_yaw_for_control_cd() const;
 
     // is the AHRS subsystem healthy?

--- a/libraries/AP_NavEKF/AP_NavEKF.h
+++ b/libraries/AP_NavEKF/AP_NavEKF.h
@@ -204,13 +204,8 @@ public:
     // return data for debugging optical flow fusion
     void getFlowDebug(float &varFlow, float &gndOffset, float &flowInnovX, float &flowInnovY, float &auxInnov, float &HAGL, float &rngInnov, float &range, float &gndOffsetErr) const;
 
-    // called by vehicle code to specify that a takeoff is happening
-    // causes the EKF to compensate for expected barometer errors due to ground effect
-    void setTakeoffExpected(bool val);
-
-    // called by vehicle code to specify that a touchdown is expected to happen
-    // causes the EKF to compensate for expected barometer errors due to ground effect
-    void setTouchdownExpected(bool val);
+    // called by vehicle code to specify the current phase of flight
+    void setFlightPhase(enum nav_filter_flight_phase flightPhase);
 
     /*
     return the filter fault status as a bitmasked integer
@@ -437,6 +432,9 @@ private:
     // Set the NED origin to be used until the next filter reset
     void setOrigin();
 
+    // get phase of flight - reverts to armed/disarmed if we didn't get an update from vehicle code
+    enum nav_filter_flight_phase getFlightPhase();
+
     // determine if a takeoff is expected so that we can compensate for expected barometer errors due to ground effect
     bool getTakeoffExpected();
 
@@ -522,7 +520,7 @@ private:
 
 
     // ground effect tuning parameters
-    const uint16_t gndEffectTimeout_ms;      // time in msec that ground effect mode is active after being activated
+    const uint16_t flightPhaseTimeout_ms;      // time in msec that ground effect mode is active after being activated
     const float gndEffectBaroScaler;    // scaler applied to the barometer observation variance when ground effect mode is active
 
 
@@ -745,12 +743,12 @@ private:
     float dtDelVel1;
     float dtDelVel2;
 
-    // baro ground effect
-    bool expectGndEffectTakeoff;      // external state from ArduCopter - takeoff expected
-    uint32_t takeoffExpectedSet_ms;   // system time at which expectGndEffectTakeoff was set
-    bool expectGndEffectTouchdown;    // external state from ArduCopter - touchdown expected
-    uint32_t touchdownExpectedSet_ms; // system time at which expectGndEffectTouchdown was set
-    float meaHgtAtTakeOff;            // height measured at commencement of takeoff
+    // flight phase
+    enum nav_filter_flight_phase flightPhase; // external state from ArduCopter - flight phase
+    uint32_t flightPhaseSet_ms;               // system time at which flightPhase was set
+
+    // barometer interference
+    float meaHgtAtTakeOff;                    // height measured at commencement of takeoff
 
     // states held by optical flow fusion across time steps
     // optical flow X,Y motion compensated rate measurements are fused across two time steps

--- a/libraries/AP_NavEKF/AP_Nav_Common.h
+++ b/libraries/AP_NavEKF/AP_Nav_Common.h
@@ -38,4 +38,12 @@ union nav_filter_status {
     uint16_t value;
 };
 
+enum nav_filter_flight_phase {
+    FLIGHT_PHASE_DISARMED = 0,
+    FLIGHT_PHASE_ARMED_PRE_TAKEOFF,
+    FLIGHT_PHASE_ARMED_TAKEOFF,
+    FLIGHT_PHASE_ARMED_FLYING,
+    FLIGHT_PHASE_ARMED_LANDING
+};
+
 #endif // AP_Nav_Common


### PR DESCRIPTION
This is intended to be non-functional... I don't think it is perfectly non-functional, because we can't have both takeoff and touchdown expected now. Previously, this was possible. Does it matter? I don't think so.

We can use the transition from ARMED_PRE_TAKEOFF to ARMED_TAKEOFF (information that the EKF did not have before) to initialize posDownAtTakeoff, which is used for the magnetometer reset. Additionally, I'd like to do an extra mag field/heading reset on the transition from ARMED_TAKEOFF to ARMED_FLYING.