### PR TITLE
check if Compass(HMC5883) is Saturated

### DIFF
--- a/ArduCopter/motors.pde
+++ b/ArduCopter/motors.pde
@@ -282,6 +282,15 @@ static bool pre_arm_checks(bool display_failure)
 
     // check Compass
     if ((g.arming_check == ARMING_CHECK_ALL) || (g.arming_check & ARMING_CHECK_COMPASS)) {
+
+        // check the primary compass is not saturated
+        if(compass.saturated()) {
+            if (display_failure) {
+                gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: Compass saturated"));
+            }
+            return false;
+        }
+
         // check the primary compass is healthy
         if(!compass.healthy()) {
             if (display_failure) {

--- a/libraries/AP_Compass/AP_Compass_Backend.cpp
+++ b/libraries/AP_Compass/AP_Compass_Backend.cpp
@@ -113,6 +113,15 @@ void AP_Compass_Backend::publish_filtered_field(const Vector3f &mag, uint8_t ins
 }
 
 /*
+  set state.saturated
+*/
+void AP_Compass_Backend::update_saturated(const bool is_saturated, uint8_t instance)
+{
+    Compass::mag_state &state = _compass._state[instance];
+    state.saturated = is_saturated;
+}
+
+/*
   register a new backend with frontend, returning instance which
   should be used in publish_field()
  */
@@ -120,7 +129,6 @@ uint8_t AP_Compass_Backend::register_compass(void) const
 { 
     return _compass.register_compass(); 
 }
-
 
 /*
   set dev_id for an instance

--- a/libraries/AP_Compass/AP_Compass_Backend.h
+++ b/libraries/AP_Compass/AP_Compass_Backend.h
@@ -63,6 +63,7 @@ protected:
     void correct_field(Vector3f &mag, uint8_t i);
     void publish_unfiltered_field(const Vector3f &mag, uint32_t time_us, uint8_t instance);
     void publish_filtered_field(const Vector3f &mag, uint8_t instance);
+    void update_saturated(const bool is_saturated, uint8_t instance);
 
     // register a new compass instance with the frontend
     uint8_t register_compass(void) const;

--- a/libraries/AP_Compass/AP_Compass_PX4.cpp
+++ b/libraries/AP_Compass/AP_Compass_PX4.cpp
@@ -134,6 +134,10 @@ void AP_Compass_PX4::accumulate(void)
         while (::read(_mag_fd[i], &mag_report, sizeof(mag_report)) == sizeof(mag_report) &&
                mag_report.timestamp != _last_timestamp[i]) {
 
+            update_saturated(mag_report.is_saturated, frontend_instance);
+            if(mag_report.is_saturated){
+                break;
+            }
             uint32_t time_us = (uint32_t)mag_report.timestamp;
             // get raw_field - sensor frame, uncorrected
             Vector3f raw_field = Vector3f(mag_report.x, mag_report.y, mag_report.z)*1.0e3f;

--- a/libraries/AP_Compass/Compass.h
+++ b/libraries/AP_Compass/Compass.h
@@ -153,6 +153,10 @@ public:
     bool healthy(void) const { return healthy(get_primary()); }
     uint8_t get_healthy_mask() const;
 
+    /// Return if compass saturated
+    bool saturated(uint8_t i) const { return _state[i].saturated; }
+    bool saturated(void) const { return saturated(get_primary()); }
+
     /// Returns the current offset values
     ///
     /// @returns                    The current compass offsets.
@@ -371,6 +375,7 @@ private:
         bool        has_unfiltered_field;
         bool        updated_raw_field;
         bool        updated_unfiltered_field;
+        bool        saturated;
         Vector3f    raw_field;
         Vector3f    unfiltered_field;
     } _state[COMPASS_MAX_INSTANCES];


### PR DESCRIPTION
This is to address the issue of compass not communicating(or healthy) and compass being saturated as same state. These commits along with https://github.com/3drobotics/PX4Firmware-solo/pull/9 will resolve this issue and compass saturated prearm fail message will be displayed in case compass measurement is saturated.