### PR TITLE
Save configuration to non-volatile memory in UBlox GPS

### DIFF
--- a/libraries/AP_GPS/AP_GPS_UBLOX.cpp
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.cpp
@@ -66,7 +66,8 @@ AP_GPS_UBLOX::AP_GPS_UBLOX(AP_GPS &_gps, AP_GPS::GPS_State &_state, AP_HAL::UART
     next_fix(AP_GPS::NO_FIX),
     rate_update_step(0),
     _last_5hz_time(0),
-    _last_hw_status(0)
+    _last_hw_status(0),
+    _cfg_saved(false)
 {
     // stop any config strings that are pending
     gps.send_blob_start(state.instance, NULL, 0);
@@ -148,6 +149,8 @@ AP_GPS_UBLOX::read(void)
 
     if (need_rate_update) {
         send_next_rate_update();
+    }else if(!_cfg_saved) {         //save the configuration sent until now
+        _save_cfg();
     }
 
     numc = port->available();
@@ -391,7 +394,9 @@ AP_GPS_UBLOX::_parse_gps(void)
             log_nak(_buffer.ack.clsID, _buffer.ack.msgID);
         }
 #endif
-
+        if(_msg_id == MSG_ACK_ACK && _buffer.ack.clsID == CLASS_CFG && _buffer.ack.msgID == MSG_CFG_CFG) {
+            _cfg_saved = true;
+        }
         return false;
     }
 
@@ -423,6 +428,7 @@ AP_GPS_UBLOX::_parse_gps(void)
             _send_message(CLASS_CFG, MSG_CFG_NAV_SETTINGS,
                           &_buffer.nav_settings,
                           sizeof(_buffer.nav_settings));
+            _cfg_saved = false;     //save configuration
         }
         return false;
     }
@@ -439,6 +445,7 @@ AP_GPS_UBLOX::_parse_gps(void)
             _send_message(CLASS_CFG, MSG_CFG_SBAS,
                           &_buffer.sbas,
                           sizeof(_buffer.sbas));
+            _cfg_saved = false;
         }
     }
 
@@ -713,6 +720,18 @@ AP_GPS_UBLOX::_configure_gps(void)
     _send_message(CLASS_CFG, MSG_CFG_NAV_SETTINGS, NULL, 0);
 }
 
+/*
+ *
+ */
+void
+AP_GPS_UBLOX::_save_cfg()
+{
+    ubx_cfg_cfg save_cfg;
+    save_cfg.clearMask = 0;
+    save_cfg.saveMask = SAVE_CFG_ALL;
+    save_cfg.loadMask = 0;
+    _send_message(CLASS_CFG, MSG_CFG_CFG, &save_cfg, sizeof(save_cfg));
+}
 
 /*
   detect a Ublox GPS. Adds one byte, and returns true if the stream

--- a/libraries/AP_GPS/AP_GPS_UBLOX.h
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.h
@@ -39,6 +39,16 @@
  */
 #define UBLOX_SET_BINARY "\265\142\006\001\003\000\001\006\001\022\117$PUBX,41,1,0003,0001,38400,0*26\r\n"
 
+//Configuration Sub-Sections
+#define SAVE_CFG_IO     (1<<0)
+#define SAVE_CFG_MSG    (1<<1)
+#define SAVE_CFG_INF    (1<<2)
+#define SAVE_CFG_NAV    (1<<3)
+#define SAVE_CFG_RXM    (1<<4)
+#define SAVE_CFG_RINV   (1<<9)
+#define SAVE_CFG_ANT    (1<<10)
+#define SAVE_CFG_ALL    (SAVE_CFG_IO|SAVE_CFG_MSG|SAVE_CFG_INF|SAVE_CFG_NAV|SAVE_CFG_RXM|SAVE_CFG_RINV|SAVE_CFG_ANT)
+
 class AP_GPS_UBLOX : public AP_GPS_Backend
 {
 public:
@@ -204,6 +214,11 @@ private:
         uint8_t clsID;
         uint8_t msgID;
     };
+    struct PACKED ubx_cfg_cfg {
+        uint32_t clearMask;
+        uint32_t saveMask;
+        uint32_t loadMask;
+    };
     // Receive buffer
     union PACKED {
         ubx_nav_posllh posllh;
@@ -233,6 +248,7 @@ private:
         MSG_STATUS = 0x3,
         MSG_SOL = 0x6,
         MSG_VELNED = 0x12,
+        MSG_CFG_CFG = 0x09,
         MSG_CFG_PRT = 0x00,
         MSG_CFG_RATE = 0x08,
         MSG_CFG_SET_RATE = 0x01,
@@ -275,6 +291,7 @@ private:
 	// processing
     uint8_t			_fix_count;
     uint8_t         _class;
+    bool            _cfg_saved;
 
     uint32_t        _last_vel_time;
     uint32_t        _last_pos_time;
@@ -305,6 +322,7 @@ private:
     void        _send_message(uint8_t msg_class, uint8_t msg_id, void *msg, uint8_t size);
     void		send_next_rate_update(void);
     void        _request_version(void);
+    void        _save_cfg(void);
 
     void unexpected_message(void);
     void write_logging_headers(void);


### PR DESCRIPTION
There is an availability in ublox-7n to store configuration inside onboard flash and BBR RAM if commanded to do so. This PR/commit makes ubx GPS driver to use this feature after any change that is made to config.