### PR TITLE
fix inertial sensor timing issues causing inaccuracies

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -135,7 +135,7 @@ public:
     float get_delta_velocity_dt(uint8_t i) const {
         return _delta_velocity_dt[i];
     }
-    float get_delta_velocity() const { return get_delta_velocity_dt(_primary_accel); }
+    float get_delta_velocity_dt() const { return get_delta_velocity_dt(_primary_accel); }
 
     /// Fetch the current accelerometer values
     ///

--- a/libraries/AP_InertialSensor/AP_InertialSensor_PX4.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_PX4.cpp
@@ -109,7 +109,6 @@ bool AP_InertialSensor_PX4::_init_sensor(void)
                 ioctl(fd, GYROIOCSSAMPLERATE, 1000);
                 // set queue depth
                 ioctl(fd, SENSORIOCSQUEUEDEPTH, _queue_depth(1000));
-                _gyro_sample_time[i] = 1.0f/1000;
                 break;
             case DRV_GYR_DEVTYPE_L3GD20:
                 // hardware LPF as high as possible
@@ -118,11 +117,12 @@ bool AP_InertialSensor_PX4::_init_sensor(void)
                 ioctl(fd, GYROIOCSSAMPLERATE, 800);
                 // 10ms queue depth
                 ioctl(fd, SENSORIOCSQUEUEDEPTH, _queue_depth(800));
-                _gyro_sample_time[i] = 1.0f/760;
                 break;
             default:
                 break;
         }
+        // calculate gyro sample time
+        _gyro_sample_time[i] = 1.0f / ioctl(fd,  GYROIOCGSAMPLERATE, 0);
     }
 
     for (uint8_t i=0; i<_num_accel_instances; i++) {
@@ -142,7 +142,6 @@ bool AP_InertialSensor_PX4::_init_sensor(void)
                 ioctl(fd, ACCELIOCSSAMPLERATE, 1000);
                 // 10ms queue depth
                 ioctl(fd, SENSORIOCSQUEUEDEPTH, _queue_depth(1000));
-                _accel_sample_time[i] = 1.0f/1000;
                 break;
             case DRV_ACC_DEVTYPE_LSM303D:
                 // hardware LPF to ~1/10th sample rate for antialiasing
@@ -152,11 +151,12 @@ bool AP_InertialSensor_PX4::_init_sensor(void)
                 ioctl(fd,SENSORIOCSPOLLRATE, 1600);
                 // 10ms queue depth
                 ioctl(fd, SENSORIOCSQUEUEDEPTH, _queue_depth(1600));
-                _accel_sample_time[i] = 1.0f/1600;
                 break;
             default:
                 break;
         }
+        // calculate accel sample time
+        _accel_sample_time[i] = 1.0f / ioctl(fd,  ACCELIOCGSAMPLERATE, 0);
     }
 
     _set_accel_filter_frequency(_accel_filter_cutoff());

--- a/libraries/AP_InertialSensor/AP_InertialSensor_PX4.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_PX4.cpp
@@ -109,6 +109,7 @@ bool AP_InertialSensor_PX4::_init_sensor(void)
                 ioctl(fd, GYROIOCSSAMPLERATE, 1000);
                 // set queue depth
                 ioctl(fd, SENSORIOCSQUEUEDEPTH, _queue_depth(1000));
+                _gyro_sample_time[i] = 1.0f/1000;
                 break;
             case DRV_GYR_DEVTYPE_L3GD20:
                 // hardware LPF as high as possible
@@ -117,6 +118,7 @@ bool AP_InertialSensor_PX4::_init_sensor(void)
                 ioctl(fd, GYROIOCSSAMPLERATE, 800);
                 // 10ms queue depth
                 ioctl(fd, SENSORIOCSQUEUEDEPTH, _queue_depth(800));
+                _gyro_sample_time[i] = 1.0f/760;
                 break;
             default:
                 break;
@@ -140,6 +142,7 @@ bool AP_InertialSensor_PX4::_init_sensor(void)
                 ioctl(fd, ACCELIOCSSAMPLERATE, 1000);
                 // 10ms queue depth
                 ioctl(fd, SENSORIOCSQUEUEDEPTH, _queue_depth(1000));
+                _accel_sample_time[i] = 1.0f/1000;
                 break;
             case DRV_ACC_DEVTYPE_LSM303D:
                 // hardware LPF to ~1/10th sample rate for antialiasing
@@ -149,6 +152,7 @@ bool AP_InertialSensor_PX4::_init_sensor(void)
                 ioctl(fd,SENSORIOCSPOLLRATE, 1600);
                 // 10ms queue depth
                 ioctl(fd, SENSORIOCSQUEUEDEPTH, _queue_depth(1600));
+                _accel_sample_time[i] = 1.0f/1600;
                 break;
             default:
                 break;
@@ -259,8 +263,8 @@ void AP_InertialSensor_PX4::_new_accel_sample(uint8_t i, accel_report &accel_rep
     // apply filter for control path
     _accel_in[i] = _accel_filter[i].apply(accel);
 
-    // compute time since last sample
-    float dt = (accel_report.timestamp - _last_accel_timestamp[i]) * 1.0e-6f;
+    // get time since last sample
+    float dt = _accel_sample_time[i];
 
     // compute delta velocity
     Vector3f delVel = Vector3f(accel.x, accel.y, accel.z) * dt;
@@ -306,8 +310,8 @@ void AP_InertialSensor_PX4::_new_gyro_sample(uint8_t i, gyro_report &gyro_report
     // apply filter for control path
     _gyro_in[i] = _gyro_filter[i].apply(gyro);
 
-    // compute time since last sample - not more than 50ms
-    float dt = min((gyro_report.timestamp - _last_gyro_timestamp[i]) * 1.0e-6f, 0.05f);
+    // get time since last sample
+    float dt = _gyro_sample_time[i];
 
     // compute delta angle
     Vector3f delAng = (gyro+_last_gyro[i]) * 0.5f * dt;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_PX4.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_PX4.h
@@ -41,6 +41,8 @@ private:
     uint64_t _last_gyro_timestamp[INS_MAX_INSTANCES];
     uint64_t _last_accel_update_timestamp[INS_MAX_INSTANCES];
     uint64_t _last_gyro_update_timestamp[INS_MAX_INSTANCES];
+    float    _accel_sample_time[INS_MAX_INSTANCES];
+    float    _gyro_sample_time[INS_MAX_INSTANCES];
     uint64_t _last_get_sample_timestamp;
     uint64_t _last_sample_timestamp;
 

--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -738,7 +738,7 @@ void NavEKF::UpdateFilter()
 
     // sum delta angles and time used by covariance prediction
     summedDelAng = summedDelAng + correctedDelAng;
-    summedDelVel = summedDelVel + correctedDelVel1;
+    summedDelVel = summedDelVel + correctedDelVel12;
     dt += dtIMUactual;
 
     // perform a covariance prediction if the total delta angle has exceeded the limit

--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -4095,7 +4095,7 @@ void NavEKF::readIMUData()
     const AP_InertialSensor &ins = _ahrs->get_ins();
 
     dtIMUavg = 1.0f/ins.get_sample_rate();
-    dtIMUactual = max(ins.get_delta_time(),1.0e-3f);
+    dtIMUactual = max(ins.get_delta_time(),1.0e-4f);
 
     // the imu sample time is used as a common time reference throughout the filter
     imuSampleTime_ms = hal.scheduler->millis();


### PR DESCRIPTION
This fixes an issue with inaccurate inertial measurements that Leonard noticed.
We suspect that this regression was caused by [this change](https://github.com/3drobotics/PX4Firmware-solo/commit/b4a2a2da878eba8196c4c00d8674dc887049b335) introducing timing jitter.