### PR TITLE
AP_NavEKF: don't start the GPS fail timer during flight or during the disarm timeout

### DIFF
--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -5162,6 +5162,15 @@ bool NavEKF::calcGpsGoodToAlign(void)
         gpsHorizVelFail = false;
     }
 
+    // return healthy if we already have an origin and are inflight to prevent a race condition when checking the status on the ground after landing
+    // return healthy for a few seconds after landing so that filter disturbances don't fail the GPS
+    bool disarmTimeout = ((imuSampleTime_ms - timeAtDisarm_ms) < 5000) && !vehicleArmed && gpsAccuracyGood;
+    bool usingInFlight = vehicleArmed && validOrigin && !constVelMode && !constPosMode;
+
+    if (disarmTimeout || usingInFlight) {
+        return true;
+    }
+
     // record time of fail
     // assume  fail first time called
     if (gpsVelFail || numSatsFail || hdopFail || hAccFail || yawFail || gpsDriftFail || gpsVertVelFail || gpsHorizVelFail || lastGpsVelFail_ms == 0) {
@@ -5169,11 +5178,7 @@ bool NavEKF::calcGpsGoodToAlign(void)
     }
 
     // continuous period without fail required to return healthy
-    // also return healthy if we already have an origin and are inflight to prevent a race condition when checking the status on the ground after landing
-    // Due to filter disturbances on landing and disarm we don't fail the GPS check status for the first 5 seconds provided the basic GPS accuracy check passes
-    bool disarmTimeout = ((imuSampleTime_ms - timeAtDisarm_ms) < 5000) && !vehicleArmed && gpsAccuracyGood;
-    bool usingInFlight = vehicleArmed && validOrigin && !constVelMode && !constPosMode;
-    if (imuSampleTime_ms - lastGpsVelFail_ms > 10000 || usingInFlight || disarmTimeout) {
+    if (imuSampleTime_ms - lastGpsVelFail_ms > 10000) {
         return true;
     } else {
         return false;


### PR DESCRIPTION
Fixes issue observed in @grant3DR 1.0.6grant_1.bin