### PR TITLE
Prevent bad alignment from upside down power up

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -137,8 +137,31 @@ AP_AHRS_DCM::reset(bool recover_eulers)
     if (recover_eulers && !isnan(roll) && !isnan(pitch) && !isnan(yaw)) {
         _dcm_matrix.from_euler(roll, pitch, yaw);
     } else {
-        // otherwise make it flat
-        _dcm_matrix.from_euler(0, 0, 0);
+
+        // Use the measured accel due to gravity to calculate an initial
+        // roll and pitch estimate
+
+        // Get body frame accel vector
+        // TODO we should average accel readings over several cycles
+        Vector3f initAccVec;
+        initAccVec = _ins.get_accel();
+
+        // normalise the acceleration vector
+        if (initAccVec.length() > 5.0f) {
+            initAccVec.normalize();
+
+            // calculate initial pitch angle
+            pitch = asinf(initAccVec.x);
+
+            // calculate initial roll angle
+            roll = -asinf(initAccVec.y / cosf(pitch));
+        } else {
+            // If we cant use the accel vector, then align flat
+            roll = 0.0f;
+            pitch = 0.0f;
+        }
+        _dcm_matrix.from_euler(roll, pitch, 0);
+
     }
 
     _last_startup_ms = hal.scheduler->millis();


### PR DESCRIPTION
This uses the gravity vector to set the inital DCM alignment, rather than align to 0,0 and wait for the error correction to converge on the correct alignment.

Addresses https://3drsolo.atlassian.net/browse/GA-56