### PR TITLE
AP_NavEKF: Prevent noisy baro readings from failing pre-flight check

### DIFF
--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -2114,7 +2114,10 @@ void NavEKF::FuseVelPosNED()
 
             // Calculate a filtered value to be used by pre-flight health checks
             // We need to filter because wind gusts can generate singificant baro noise and we want to be able to detect bias errors in the inertial solution
-            hgtInnovFiltState = 0.05f*innovVelPos[5] + 0.95f*hgtInnovFiltState;
+            static const float dtBaro = msecHgtAvg*1.0e-3f;
+            static const float hgtInnovFiltTC = 2.0f;
+            static const float alpha = constrain_float(dtBaro/(dtBaro+hgtInnovFiltTC),0.0f,1.0f);
+            hgtInnovFiltState += (innovVelPos[5]-hgtInnovFiltState)*alpha;
 
             varInnovVelPos[5] = P[9][9] + R_OBS_DATA_CHECKS[5];
             // calculate the innovation consistency test ratio

--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -449,7 +449,7 @@ bool NavEKF::healthy(void) const
     }
     // barometer and position innovations must be within limits when on-ground
     float horizErrSq = sq(innovVelPos[3]) + sq(innovVelPos[4]);
-    if (!vehicleArmed && (fabsf(innovVelPos[5]) > 1.0f || horizErrSq > 2.0f)) {
+    if (!vehicleArmed && (fabsf(hgtInnovFiltState) > 1.0f || horizErrSq > 2.0f)) {
         return false;
     }
 
@@ -2111,6 +2111,10 @@ void NavEKF::FuseVelPosNED()
         if (fuseHgtData) {
             // calculate height innovations
             innovVelPos[5] = statesAtHgtTime.position.z - observation[5];
+
+            // Calculate a filtered value to be used by pre-flight health checks
+            // We need to filter because wind gusts can generate singificant baro noise and we want to be able to detect bias errors in the inertial solution
+            hgtInnovFiltState = 0.05f*innovVelPos[5] + 0.95f*hgtInnovFiltState;
 
             varInnovVelPos[5] = P[9][9] + R_OBS_DATA_CHECKS[5];
             // calculate the innovation consistency test ratio
@@ -4680,6 +4684,7 @@ void NavEKF::InitialiseVariables()
     gpsDriftNE = 0.0f;
     gpsVertVelFilt = 0.0f;
     gpsHorizVelFilt = 0.0f;
+    hgtInnovFiltState = 0.0f;
 }
 
 // return true if we should use the airspeed sensor

--- a/libraries/AP_NavEKF/AP_NavEKF.h
+++ b/libraries/AP_NavEKF/AP_NavEKF.h
@@ -676,6 +676,7 @@ private:
     float gpsDriftNE;               // amount of drift detected in the GPS position during pre-flight GPs checks
     float gpsVertVelFilt;           // amount of filterred vertical GPS velocity detected durng pre-flight GPS checks
     float gpsHorizVelFilt;          // amount of filtered horizontal GPS velocity detected during pre-flight GPS checks
+    float hgtInnovFiltState;        // state used for fitering of the height innovations used for pre-flight checks
 
     // Used by smoothing of state corrections
     Vector10 gpsIncrStateDelta;    // vector of corrections to attitude, velocity and position to be applied over the period between the current and next GPS measurement


### PR DESCRIPTION
Wind gusts can cause baro fluctuations that are failing the pre-flight health check. This applies a filter to the innovation sequence to reduce the effect of zero mean noise.

Addresses probable cause of https://3drsolo.atlassian.net/browse/FC-240