### PR TITLE
Prevent failure to use GPS due to change in magnetic field after startup

### DIFF
--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -296,21 +296,6 @@
  #endif
 #endif
 
-// arming check's maximum acceptable vector difference between internal and external compass after vectors are normalized to field length of 1.0
-#ifndef COMPASS_ACCEPTABLE_VECTOR_DIFF
-  #define COMPASS_ACCEPTABLE_VECTOR_DIFF    0.75    // pre arm compass check will fail if internal vs external compass direction differ by more than 45 degrees
- #endif
-
-// maximum heading discrepancy in radians allowed between compass 1 and 2 for pre-arm checks
-#ifndef MAX_COMPASS_XY_ANG_DIFF
- #define MAX_COMPASS_XY_ANG_DIFF radians(30.0f)
-#endif
-
-// maximum length of XY discrepancy allowed between compass 1 and 2 for pre-arm checks
-#ifndef MAX_COMPASS_XY_LENGTH_DIFF
- #define MAX_COMPASS_XY_LENGTH_DIFF 100.0f
-#endif
-
 //////////////////////////////////////////////////////////////////////////////
 //  OPTICAL_FLOW
 #ifndef OPTFLOW

--- a/ArduCopter/motors.pde
+++ b/ArduCopter/motors.pde
@@ -316,44 +316,12 @@ static bool pre_arm_checks(bool display_failure)
             return false;
         }
 
-#if COMPASS_MAX_INSTANCES > 1
-        // check all compasses point in roughly same direction and apply a more stringent check in the XY plane
-        if (compass.get_count() > 1) {
-            Vector3f prime_mag_vec = compass.get_field();
-            Vector3f prime_mag_vec_norm = prime_mag_vec;
-            prime_mag_vec_norm.normalize();
-            for(uint8_t i=0; i<compass.get_count(); i++) {
-                if (!compass.use_for_yaw(i)) {
-                    continue;
-                }
-                // get next compass
-                Vector3f mag_vec = compass.get_field(i);
-                Vector3f mag_vec_norm = mag_vec;
-                mag_vec_norm.normalize();
-                Vector3f vec_diff = mag_vec_norm - prime_mag_vec_norm;
-
-                // check for gross misalignment on all axes
-                bool vector_diff_large = vec_diff.length() > COMPASS_ACCEPTABLE_VECTOR_DIFF;
-
-                // check for an unacceptable angle difference on the xy plane
-                float angDiff_XY = wrap_PI((atan2f(prime_mag_vec.y,prime_mag_vec.x) - atan2f(mag_vec.y,mag_vec.x)));
-                bool xy_angle_diff_large = fabsf(angDiff_XY) > MAX_COMPASS_XY_ANG_DIFF;
-
-                // check for an unacceptable length difference on the xy plane
-                float lengthDiff_XY = sqrtf(sq(prime_mag_vec.x - mag_vec.x) + sq(prime_mag_vec.y - mag_vec.y));
-                bool xy_length_diff_large = lengthDiff_XY > MAX_COMPASS_XY_LENGTH_DIFF;
-
-                // check for inconsistency in the XY plane
-                if (vector_diff_large || xy_angle_diff_large || xy_length_diff_large) {
-                    if (display_failure) {
-                        gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: inconsistent compasses"));
-                    }
-                    return false;
-                }
+        if (!compass.consistent()) {
+            if (display_failure) {
+                gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: inconsistent compasses"));
             }
+            return false;
         }
-#endif
-
     }
 
     // check GPS

--- a/libraries/AP_Compass/Compass.h
+++ b/libraries/AP_Compass/Compass.h
@@ -45,6 +45,10 @@
 #define COMPASS_MAX_BACKEND   1   
 #endif
 
+#define AP_COMPASS_MAX_XYZ_ANG_DIFF radians(50.0f)
+#define AP_COMPASS_MAX_XY_ANG_DIFF radians(30.0f)
+#define AP_COMPASS_MAX_XY_LENGTH_DIFF 100.0f
+
 class Compass
 {
 friend class AP_Compass_Backend;
@@ -147,6 +151,10 @@ public:
 
     void send_mag_cal_progress(mavlink_channel_t chan);
     void send_mag_cal_report(mavlink_channel_t chan);
+
+    uint8_t get_use_mask() const;
+    bool consistent(uint8_t mask) const;
+    bool consistent() const { return consistent(get_use_mask()); }
 
     /// Return the health of a compass
     bool healthy(uint8_t i) const { return _state[i].healthy; }

--- a/libraries/AP_NavEKF/AP_NavEKF.h
+++ b/libraries/AP_NavEKF/AP_NavEKF.h
@@ -676,6 +676,8 @@ private:
     float gpsDriftNE;               // amount of drift detected in the GPS position during pre-flight GPs checks
     float gpsVertVelFilt;           // amount of filterred vertical GPS velocity detected durng pre-flight GPS checks
     float gpsHorizVelFilt;          // amount of filtered horizontal GPS velocity detected during pre-flight GPS checks
+    uint32_t magYawResetTimer_ms;   // timer in msec used to track how long good magnetometer data is failing innovation consistency checks
+    bool consistentMagData;         // true when the magnetometers are passing consistency checks
 
     // Used by smoothing of state corrections
     Vector10 gpsIncrStateDelta;    // vector of corrections to attitude, velocity and position to be applied over the period between the current and next GPS measurement


### PR DESCRIPTION
Same as #153 but PRed on solo-U1.1 base.

>If we change the magnetic field environment after startup, the innovations in magnetic field states can cause the EKF to not pass the GPS checks due to uncertainty in heading.

>This patch checks for consistency in magnetometers and if they are consistent and innovation checks are failing for longer than 5 seconds, the magnetic field and yaw angle is reset which will enable the check to pass if the EKF solution is stable.

>It requires the compass consistency check methods introduced by https://github.com/3drobotics/ardupilot-solo/tree/solo-pr-mag-consistent