### PR TITLE
AP_Compass: only play compass cal cancel tone if a cal was running

### DIFF
--- a/libraries/AP_Compass/AP_Compass_Calibration.cpp
+++ b/libraries/AP_Compass/AP_Compass_Calibration.cpp
@@ -6,7 +6,7 @@
 void
 Compass::compass_cal_update()
 {
-    AP_Notify::flags.compass_cal_running = 0;
+    bool running = false;
 
     for (uint8_t i=0; i<COMPASS_MAX_INSTANCES; i++) {
         bool failure;
@@ -21,9 +21,10 @@ Compass::compass_cal_update()
         }
 
         if (_calibrator[i].running()) {
-            AP_Notify::flags.compass_cal_running = 1;
+            running = true;
         }
     }
+    AP_Notify::flags.compass_cal_running = running;
 }
 
 bool

--- a/libraries/AP_Compass/AP_Compass_Calibration.cpp
+++ b/libraries/AP_Compass/AP_Compass_Calibration.cpp
@@ -77,9 +77,12 @@ Compass::start_calibration_all(bool retry, bool autosave, float delay)
 void
 Compass::cancel_calibration(uint8_t i)
 {
-    _calibrator[i].clear();
-    AP_Notify::events.compass_cal_canceled = 1;
     AP_Notify::events.initiated_compass_cal = 0;
+
+    if (_calibrator[i].running() || _calibrator[i].get_status() == COMPASS_CAL_WAITING_TO_START) {
+        AP_Notify::events.compass_cal_canceled = 1;
+    }
+    _calibrator[i].clear();
 }
 
 void


### PR DESCRIPTION
Android app is sending extraneous compass cal cancel commands. This prevents them from playing a sound.