### PR TITLE
AP_NavEKF: Provide guaranteed minimum fusion rates for non-GPS operation

### DIFF
--- a/libraries/AP_NavEKF/AP_NavEKF.h
+++ b/libraries/AP_NavEKF/AP_NavEKF.h
@@ -679,6 +679,7 @@ private:
     uint32_t magYawResetTimer_ms;   // timer in msec used to track how long good magnetometer data is failing innovation consistency checks
     bool consistentMagData;         // true when the magnetometers are passing consistency checks
     float hgtInnovFiltState;        // state used for fitering of the height innovations used for pre-flight checks
+    uint32_t lastConstPosFuseTime_ms;   // last time in msec the constant position constraint was applied
 
     // Used by smoothing of state corrections
     Vector10 gpsIncrStateDelta;    // vector of corrections to attitude, velocity and position to be applied over the period between the current and next GPS measurement
@@ -735,8 +736,6 @@ private:
     float flowUpdateCountMaxInv;    // floating point inverse of flowUpdateCountMax
     Vector10 flowIncrStateDelta;   // vector of corrections to attitude, velocity and position to be applied over the period between the current and next magnetometer measurement
     bool newDataRng;                // true when new valid range finder data has arrived.
-    bool constVelMode;              // true when fusing a constant velocity to maintain attitude reference when either optical flow or GPS measurements are lost after arming
-    bool lastConstVelMode;          // last value of holdVelocity
     Vector2f heldVelNE;             // velocity held when no aiding is available
     enum AidingMode {AID_ABSOLUTE=0,    // GPS aiding is being used (optical flow may also be used) so position estimates are absolute.
                       AID_NONE=1,       // no aiding is being used so only attitude and height estimates are available. Either constVelMode or constPosMode must be used to constrain tilt drift.


### PR DESCRIPTION
This patch prevents the possibility of high measurement rates on the magnetometer or baro blocking the fusion of synthetic position and velocity during non-GPs operation. This vulnerability in combination with a defect in the SITL measurement rates caused the EKF on SITL to diverge in the tie period before arming.
The constant velocity mode which was not used has been removed to make the non-aiding logic simpler
The zero position and velocity observations are now fused at the same time as the baro observations which ensures consistent covariance for all position and velocity fusion and increases aiding to 10Hz which is preferable to the variable rate used previously.