### PR TITLE
Ensure bad mag data cannot cause the heading to reset too often

### DIFF
--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -5106,6 +5106,8 @@ bool NavEKF::calcGpsGoodToAlign(void)
         Vector3f eulerAngles;
         getEulerAngles(eulerAngles);
         state.quat = calcQuatAndFieldStates(eulerAngles.x, eulerAngles.y);
+        // reset timer to ensure that bad magnetometer data cannot cause a heading reset more often than every 5 seconds
+        magYawResetTimer_ms = imuSampleTime_ms;
     }
 
     // fail if magnetometer innovations are outside limits indicating bad yaw


### PR DESCRIPTION
This change was identified during code review for integration of Solo EKF updates into ArduCopter master.

It closes a potential  vulnerability whereby a bad and rapidly fluctuating compass could cause heading resets avery 200 msec  during flight without GPS.