### PR TITLE
Add detection for number of cores and separate clean and distclean 

### DIFF
--- a/Tools/scripts/build_px4_v2_quad_travis.sh
+++ b/Tools/scripts/build_px4_v2_quad_travis.sh
@@ -16,7 +16,7 @@ popd
 pushd ArduCopter
 make configure
 make clean
-make px4-cleandep
+make px4-distclean
 make px4-v2
 popd
 


### PR DESCRIPTION
Developer should not be forced to clean archives everytime he/she make cleans. make px4-clean will clean up all build directories including PX4Firmware, while developer needs to pass make px4-distclean when he/she wants to clean archives too. make px4-v2 will run using parallel compilation by default based on number of cores available on the system.