### PR TITLE
Fix critical out of range indexing bug

### DIFF
--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -2868,7 +2868,7 @@ void NavEKF::FuseOptFlow()
     Vector3f velNED_local;
     Vector3f relVelSensor;
 
-    uint8_t &obsIndex = flow_state.obsIndex;
+    uint8_t obsIndex = flow_state.obsIndex;
     ftype &q0 = flow_state.q0;
     ftype &q1 = flow_state.q1;
     ftype &q2 = flow_state.q2;


### PR DESCRIPTION
This bug causes a Vector2f to be stored as an address