### PR TITLE
Added moving average to SITL baro and magnetometer 

### DIFF
--- a/libraries/AP_Compass/Compass.cpp
+++ b/libraries/AP_Compass/Compass.cpp
@@ -732,7 +732,6 @@ void Compass::setHIL(float roll, float pitch, float yaw)
 void Compass::setHIL(const Vector3f &mag)
 {
     _hil.field = mag;
-    _last_update_usec = hal.scheduler->micros();
 }
 
 const Vector3f& Compass::getHIL() const {

--- a/libraries/AP_HAL_AVR_SITL/sitl_barometer.cpp
+++ b/libraries/AP_HAL_AVR_SITL/sitl_barometer.cpp
@@ -83,14 +83,9 @@ void SITL_State::_update_barometer(float altitude)
         sim_alt = buffer_baro[best_index_baro].data;
     }
 
-    //1000 sample rolling average
-    if (sim_alt_avg == 0){
-        sim_alt_avg = sim_alt;
-    }
-    else{
-        sim_alt_avg -= sim_alt_avg / 1000.0;
-        sim_alt_avg += sim_alt / 1000.0;
-    }
+    // Average last 10 samples
+    sim_alt_avg -= sim_alt_avg / 10.0;
+    sim_alt_avg += sim_alt / 10.0;
 
     // 10Hz reporting rate
     if ((now - last_update) < 100) {

--- a/libraries/AP_HAL_AVR_SITL/sitl_barometer.cpp
+++ b/libraries/AP_HAL_AVR_SITL/sitl_barometer.cpp
@@ -30,6 +30,7 @@ extern const AP_HAL::HAL& hal;
 void SITL_State::_update_barometer(float altitude)
 {
     static uint32_t last_update;
+    static float sim_alt_avg;
 
     float sim_alt = altitude;
 
@@ -43,12 +44,7 @@ void SITL_State::_update_barometer(float altitude)
         return;
     }
 
-    // 80Hz, to match the real APM2 barometer
     uint32_t now = hal.scheduler->millis();
-    if ((now - last_update) < 12) {
-        return;
-    }
-    last_update = now;
 
     sim_alt += _sitl->baro_drift * now / 1000;
     sim_alt += _sitl->baro_noise * _rand_float();
@@ -87,7 +83,21 @@ void SITL_State::_update_barometer(float altitude)
         sim_alt = buffer_baro[best_index_baro].data;
     }
 
-    _barometer->setHIL(sim_alt);
+    //1000 sample rolling average
+    if (sim_alt_avg == 0){
+        sim_alt_avg = sim_alt;
+    }
+    else{
+        sim_alt_avg -= sim_alt_avg / 1000.0;
+        sim_alt_avg += sim_alt / 1000.0;
+    }
+
+    // 10Hz reporting rate
+    if ((now - last_update) < 100) {
+        return;
+    }
+    _barometer->setHIL(sim_alt_avg);  
+    last_update = now;
 }
 
 #endif

--- a/libraries/AP_HAL_AVR_SITL/sitl_compass.cpp
+++ b/libraries/AP_HAL_AVR_SITL/sitl_compass.cpp
@@ -91,7 +91,7 @@ void SITL_State::_update_compass(float rollDeg, float pitchDeg, float yawDeg)
     if ((now - last_update) < 100) {
         return;
     }
-    _compass->setHIL(new_mag_data);
+    _compass->setHIL(new_mag_data_avg);
     last_update = now; 
 }
 

--- a/libraries/AP_HAL_AVR_SITL/sitl_compass.cpp
+++ b/libraries/AP_HAL_AVR_SITL/sitl_compass.cpp
@@ -29,6 +29,9 @@ using namespace AVR_SITL;
  */
 void SITL_State::_update_compass(float rollDeg, float pitchDeg, float yawDeg)
 {
+    static uint32_t last_update;
+    static Vector3f new_mag_data_avg;
+
     if (_compass == NULL) {
         // no compass in this sketch
         return;
@@ -40,12 +43,14 @@ void SITL_State::_update_compass(float rollDeg, float pitchDeg, float yawDeg)
     if (yawDeg < -180.0f) {
         yawDeg += 360.0f;
     }
+
     _compass->setHIL(radians(rollDeg), radians(pitchDeg), radians(yawDeg));
     Vector3f noise = _rand_vec3f() * _sitl->mag_noise;
     Vector3f motor = _sitl->mag_mot.get() * _current;
     Vector3f new_mag_data = _compass->getHIL() + noise + motor;
 
     uint32_t now = hal.scheduler->millis();
+
     // add delay
     uint32_t best_time_delta_mag = 1000; // initialise large time representing buffer entry closest to current time - delay.
     uint8_t best_index_mag = 0; // initialise number representing the index of the entry in buffer closest to delay.
@@ -78,7 +83,23 @@ void SITL_State::_update_compass(float rollDeg, float pitchDeg, float yawDeg)
 
     new_mag_data -= _sitl->mag_ofs.get();
 
+    //1000 sample rolling average
+    if (new_mag_data_avg.length() == 0){
+        new_mag_data_avg = new_mag_data;
+    }
+    else{
+    	new_mag_data_avg -= new_mag_data_avg / 1000.0;
+    	new_mag_data_avg += new_mag_data / 1000.0;
+    }
+
+    // 10Hz reporting rate
+    if ((now - last_update) < 100) {
+        return;
+    }
     _compass->setHIL(new_mag_data);
+    last_update = now;
+
+    
 }
 
 #endif

--- a/libraries/AP_HAL_AVR_SITL/sitl_compass.cpp
+++ b/libraries/AP_HAL_AVR_SITL/sitl_compass.cpp
@@ -83,23 +83,16 @@ void SITL_State::_update_compass(float rollDeg, float pitchDeg, float yawDeg)
 
     new_mag_data -= _sitl->mag_ofs.get();
 
-    //1000 sample rolling average
-    if (new_mag_data_avg.length() == 0){
-        new_mag_data_avg = new_mag_data;
-    }
-    else{
-    	new_mag_data_avg -= new_mag_data_avg / 1000.0;
-    	new_mag_data_avg += new_mag_data / 1000.0;
-    }
+    //Average last 10 samples
+	new_mag_data_avg -= new_mag_data_avg / 10.0;
+	new_mag_data_avg += new_mag_data / 10.0;
 
     // 10Hz reporting rate
     if ((now - last_update) < 100) {
         return;
     }
     _compass->setHIL(new_mag_data);
-    last_update = now;
-
-    
+    last_update = now; 
 }
 
 #endif


### PR DESCRIPTION
and lowered reporting rate to 10Hz. Also removed an update of _last_update_usec in setHIL() since it was already being updated by publish_filtered_field(). This should help address some of the EKF SITL issues per FC-207. 

Ready for review @jschall and anyone else you feel might want to take a look.