### PR TITLE
Adds polyfill for feenableexcept on OS X.

### DIFF
--- a/libraries/AP_HAL_AVR_SITL/Scheduler.cpp
+++ b/libraries/AP_HAL_AVR_SITL/Scheduler.cpp
@@ -8,6 +8,7 @@
 #include <sys/time.h>
 #include <unistd.h>
 #include <fenv.h>
+#include "fenv_polyfill.h"
 #include <signal.h>
 #include <pthread.h>
 

--- a/libraries/AP_HAL_AVR_SITL/fenv_polyfill.h
+++ b/libraries/AP_HAL_AVR_SITL/fenv_polyfill.h
@@ -1,0 +1,32 @@
+
+#ifndef __FENV_POLYFILL_H__
+#define __FENV_POLYFILL_H__
+
+#if (defined __APPLE__) && (defined(__i386__) || defined(__x86_64__))
+
+#include <fenv.h>
+
+// Public domain polyfill for feenableexcept on OS X
+// http://www-personal.umich.edu/~williams/archive/computation/fe-handling-example.c
+
+inline int
+feenableexcept (unsigned int excepts)
+{
+  static fenv_t fenv;
+  unsigned int new_excepts = excepts & FE_ALL_EXCEPT,
+               old_excepts;  // previous masks
+
+  if ( fegetenv (&fenv) ) return -1;
+  old_excepts = fenv.__control & FE_ALL_EXCEPT;
+
+  // unmask
+  fenv.__control &= ~new_excepts;
+  fenv.__mxcsr   &= ~(new_excepts << 7);
+
+  return ( fesetenv (&fenv) ? -1 : old_excepts );
+}
+
+#endif // APPLE
+
+#endif // __FENV_POLYFILL_H__
+

--- a/libraries/AP_HAL_AVR_SITL/sitl_ins.cpp
+++ b/libraries/AP_HAL_AVR_SITL/sitl_ins.cpp
@@ -24,6 +24,7 @@
 #include "../AP_ADC/AP_ADC.h"
 #include <SITL_State.h>
 #include <fenv.h>
+#include "fenv_polyfill.h"
 
 extern const AP_HAL::HAL& hal;
 


### PR DESCRIPTION
I couldn't build SITL on OS X for two reasons. This fix I upstreamed: https://github.com/diydrones/ardupilot/commit/9d26bc6958f853de9a6239a9b4f548a64acc9e40

The other was a bug that wouldn't let me compile without Dataflash logging.