### PR TITLE
AP_NavEKF: Allow for larger gyro bias errors

### DIFF
--- a/libraries/AP_NavEKF/AP_SmallEKF.h
+++ b/libraries/AP_NavEKF/AP_SmallEKF.h
@@ -145,6 +145,10 @@ private:
     uint32_t imuSampleTime_ms;
     float dtIMU;
 
+    // States used for unwrapping of compass yaw error
+    float innovationIncrement;
+    float lastInnovation;
+
     // state prediction
     void predictStates();
 


### PR DESCRIPTION
MPU6000 data sheet indicates that variation on gyro ZRO across temperature range from -40 to +85 is +-20 deg/sec.
The limits on the gyro bias states have been increased to allow for this.
To enable the gimbal EKF to accommodate such large gyro bias values in yaw without the yaw error wrapping, leading to continual heading drift, an unwrap function has been applied to the compass heading error.