### PR TITLE
Don't allow entering RTL if GPS is glitching

### DIFF
--- a/ArduCopter/control_rtl.pde
+++ b/ArduCopter/control_rtl.pde
@@ -19,6 +19,10 @@ struct rtl_path_t {
 // rtl_init - initialise rtl controller
 static bool rtl_init(bool ignore_checks)
 {
+    if (!ignore_checks && failsafe.gps_glitch) {
+        return false;
+    }
+
     if (position_ok() || ignore_checks) {
         rtl_build_path();
         rtl_climb_start();


### PR DESCRIPTION
Every mode that needs GPS can't enter when GPS is glitching but RTL can.