### PR TITLE
Adjust SITL sensor rates

### DIFF
--- a/libraries/AP_Baro/AP_Baro.h
+++ b/libraries/AP_Baro/AP_Baro.h
@@ -7,6 +7,7 @@
 #include <AP_Param.h>
 #include <Filter.h>
 #include <DerivativeFilter.h>
+#include <AP_Buffer.h>
 
 // maximum number of sensor instances
 #if HAL_CPU_CLASS == HAL_CPU_CLASS_16
@@ -116,6 +117,12 @@ public:
 
     // HIL (and SITL) interface, setting pressure and temperature
     void setHIL(uint8_t instance, float pressure, float temperature);
+
+    // HIL variables
+    struct {
+        AP_Buffer<float,10> press_buffer;
+        AP_Buffer<float,10> temp_buffer;
+    } _hil;
 
     // register a new sensor, claiming a sensor slot. If we are out of
     // slots it will panic

--- a/libraries/AP_Baro/AP_Baro_HIL.h
+++ b/libraries/AP_Baro/AP_Baro_HIL.h
@@ -13,7 +13,7 @@ class AP_Baro_HIL : public AP_Baro_Backend
 {
 public:
     AP_Baro_HIL(AP_Baro &baro);
-    void update() {}
+    void update(void);
 
 private:
     uint8_t _instance;

--- a/libraries/AP_Compass/AP_Compass_HIL.cpp
+++ b/libraries/AP_Compass/AP_Compass_HIL.cpp
@@ -57,8 +57,41 @@ AP_Compass_HIL::init(void)
 
 void AP_Compass_HIL::read()
 {
-    Vector3f field = _compass._hil.field;
-    rotate_field(field, _compass_instance);
-    correct_field(field, _compass_instance);
-    publish_filtered_field(field, _compass_instance);
+    // try to accumulate one more sample, so we have the latest data
+    accumulate();
+
+    if (_count == 0) return;
+
+    _sum /= _count;
+
+    publish_filtered_field(_sum, _compass_instance);
+
+    _sum.zero();
+    _count = 0;
+}
+
+void AP_Compass_HIL::accumulate(void)
+{
+  while (_compass._hil.field_buffer.is_empty() == false){
+    Vector3f raw_field;
+
+    _compass._hil.field_buffer.pop_front(raw_field);
+
+    //uint32_t time_us = (uint32_t)mag_report.timestamp;
+    // rotate raw_field from sensor frame to body frame
+    rotate_field(raw_field, _compass_instance);
+
+    // publish raw_field (uncorrected point sample) for calibration use
+    //publish_raw_field(raw_field, time_us, frontend_instance);
+
+    // correct raw_field for known errors
+    correct_field(raw_field, _compass_instance);
+
+    // publish raw_field (corrected point sample) for EKF use
+    //publish_unfiltered_field(raw_field, time_us, frontend_instance);
+
+    // accumulate into averaging filter
+    _sum += raw_field;
+    _count++;
+  }
 }

--- a/libraries/AP_Compass/AP_Compass_HIL.cpp
+++ b/libraries/AP_Compass/AP_Compass_HIL.cpp
@@ -74,21 +74,22 @@ void AP_Compass_HIL::accumulate(void)
 {
   while (_compass._hil.field_buffer.is_empty() == false){
     Vector3f raw_field;
+    uint32_t time_us = 0;
 
     _compass._hil.field_buffer.pop_front(raw_field);
+    _compass._hil.field_time_us.pop_front(time_us);
 
-    //uint32_t time_us = (uint32_t)mag_report.timestamp;
     // rotate raw_field from sensor frame to body frame
     rotate_field(raw_field, _compass_instance);
 
     // publish raw_field (uncorrected point sample) for calibration use
-    //publish_raw_field(raw_field, time_us, frontend_instance);
+    publish_raw_field(raw_field, time_us, _compass_instance);
 
     // correct raw_field for known errors
     correct_field(raw_field, _compass_instance);
 
     // publish raw_field (corrected point sample) for EKF use
-    //publish_unfiltered_field(raw_field, time_us, frontend_instance);
+    publish_unfiltered_field(raw_field, time_us, _compass_instance);
 
     // accumulate into averaging filter
     _sum += raw_field;

--- a/libraries/AP_Compass/AP_Compass_HIL.h
+++ b/libraries/AP_Compass/AP_Compass_HIL.h
@@ -10,12 +10,15 @@ public:
     AP_Compass_HIL(Compass &compass);
     void read(void);
     bool init(void);
+    void accumulate(void);
 
     // detect the sensor
     static AP_Compass_Backend *detect(Compass &compass);
 
 private:
-    uint8_t     _compass_instance;    
+	uint8_t     _compass_instance;
+	Vector3f _sum;
+    uint32_t _count;
 };
 
 #endif

--- a/libraries/AP_Compass/Compass.cpp
+++ b/libraries/AP_Compass/Compass.cpp
@@ -733,6 +733,7 @@ void Compass::setHIL(const Vector3f &mag)
 {
     _hil.field = mag;
     _hil.field_buffer.push_back(mag);
+    _hil.field_time_us.push_back(hal.scheduler->micros());
 }
 
 const Vector3f& Compass::getHIL() const {

--- a/libraries/AP_Compass/Compass.cpp
+++ b/libraries/AP_Compass/Compass.cpp
@@ -732,7 +732,7 @@ void Compass::setHIL(float roll, float pitch, float yaw)
 void Compass::setHIL(const Vector3f &mag)
 {
     _hil.field = mag;
-    _last_update_usec = hal.scheduler->micros();
+    _hil.field_buffer.push_back(mag);
 }
 
 const Vector3f& Compass::getHIL() const {

--- a/libraries/AP_Compass/Compass.h
+++ b/libraries/AP_Compass/Compass.h
@@ -11,6 +11,7 @@
 #include <GCS_MAVLink.h>
 #include "CompassCalibrator.h"
 #include "AP_Compass_Backend.h"
+#include <AP_Buffer.h>
 
 // compass product id
 #define AP_COMPASS_TYPE_UNKNOWN         0x00
@@ -293,6 +294,7 @@ public:
         Vector3f Bearth;
         float last_declination;
         Vector3f field;
+        AP_Buffer<Vector3f,10> field_buffer;
     } _hil;
 
 private:

--- a/libraries/AP_Compass/Compass.h
+++ b/libraries/AP_Compass/Compass.h
@@ -295,6 +295,7 @@ public:
         float last_declination;
         Vector3f field;
         AP_Buffer<Vector3f,10> field_buffer;
+        AP_Buffer<uint32_t,10> field_time_us;
     } _hil;
 
 private:

--- a/libraries/AP_HAL_AVR_SITL/sitl_compass.cpp
+++ b/libraries/AP_HAL_AVR_SITL/sitl_compass.cpp
@@ -29,6 +29,8 @@ using namespace AVR_SITL;
  */
 void SITL_State::_update_compass(float rollDeg, float pitchDeg, float yawDeg)
 {
+    static uint32_t last_update;
+
     if (_compass == NULL) {
         // no compass in this sketch
         return;
@@ -45,7 +47,13 @@ void SITL_State::_update_compass(float rollDeg, float pitchDeg, float yawDeg)
     Vector3f motor = _sitl->mag_mot.get() * _current;
     Vector3f new_mag_data = _compass->getHIL() + noise + motor;
 
+    // 100Hz, to match the real APM2 compass
     uint32_t now = hal.scheduler->millis();
+    if ((now - last_update) < 10) {
+        return;
+    }
+    last_update = now;
+
     // add delay
     uint32_t best_time_delta_mag = 1000; // initialise large time representing buffer entry closest to current time - delay.
     uint8_t best_index_mag = 0; // initialise number representing the index of the entry in buffer closest to delay.


### PR DESCRIPTION
Averages SITL compass and barometer readings so they're read at 10Hz. This addresses EKF variance issues in SITL.