### PR TITLE
AP_HAL_AVR_SITL: allow for more data before GPS pipe flush

### DIFF
--- a/libraries/AP_HAL_AVR_SITL/sitl_gps.cpp
+++ b/libraries/AP_HAL_AVR_SITL/sitl_gps.cpp
@@ -48,7 +48,7 @@ ssize_t SITL_State::gps_read(int fd, void *buf, size_t count)
 #ifdef FIONREAD
 	// use FIONREAD to get exact value if possible
 	int num_ready;
-	while (ioctl(fd, FIONREAD, &num_ready) == 0 && num_ready > 256) {
+	while (ioctl(fd, FIONREAD, &num_ready) == 0 && num_ready > 3000) {
 		// the pipe is filling up - drain it
 		uint8_t tmp[128];
 		if (read(fd, tmp, sizeof(tmp)) != sizeof(tmp)) {


### PR DESCRIPTION
Modification pulled from upstream. Could not cherry pick due to the SITL rename (see https://github.com/diydrones/ardupilot/commit/88a90495b2ef98538c5eec522fce8298deea4555). Prevents SITL GPS from turning off/on again during the arm process. Occasionally this could cause the copter to enter "LAND" mode.