### PR TITLE
Fixes missing symbols in dataflash log while compiling SITL.

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -808,11 +808,13 @@ void
 GCS_MAVLINK::handle_remote_log_status(const mavlink_message_t *msg, DataFlash_MAVLink &DataFlash){
     mavlink_remote_log_block_status_t packet;
     mavlink_msg_remote_log_block_status_decode(msg, &packet);
+#if HAL_BOARD_REMOTE_LOG_PORT
     if(packet.block_status == 0){
         DataFlash.handle_retry(packet.block_cnt);
     } else{
         DataFlash.handle_ack(packet.block_cnt);
     }
+#endif
 }
 // send a message using mavlink, handling message queueing
 void GCS_MAVLINK::send_message(enum ap_message id)


### PR DESCRIPTION
This was needed for building Solo SITL (on OS X?), or I got this error:

```
%% ArduCopter.elf
Undefined symbols for architecture x86_64:
  "DataFlash_MAVLink::handle_ack(unsigned int)", referenced from:
      GCS_MAVLINK::handle_remote_log_status(__mavlink_message const*, DataFlash_MAVLink&)   in GCS_Common.o
  "DataFlash_MAVLink::handle_retry(unsigned int)", referenced from:
      GCS_MAVLINK::handle_remote_log_status(__mavlink_message const*, DataFlash_MAVLink&)   in GCS_Common.o
ld: symbol(s) not found for architecture x86_64
collect2: error: ld returned 1 exit status
make: *** [/Users/timryan/3dr/dronekit-sitl/stage/build/staging/ArduCopter.elf] Error 1
```