### PR TITLE
Improve in-flight reset of earth frame magnetic field states - JIRA SOLO-564

### DIFF
--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -950,6 +950,34 @@ void NavEKF::SelectMagFusion()
     // determine if conditions are right to start a new fusion cycle
     bool dataReady = statesInitialised && use_compass() && newDataMag;
     if (dataReady) {
+        // Calculate change in angle since last magetoemter fusion - used to check if in-flight alignment can be performed
+        // Use a quaternion division to calcualte the delta quaternion between the rotation at the current and last time
+        Quaternion deltaQuat = state.quat / prevQuatMagReset;
+        prevQuatMagReset = state.quat;
+        // convert the quaternion to a rotation vector and find its length
+        Vector3f deltaRotVec;
+        deltaQuat.to_axis_angle(deltaRotVec);
+        float deltaRot = deltaRotVec.length();
+
+        // Check if the magnetic field states should be reset
+        if (vehicleArmed && !firstMagYawInit && (state.position.z  - posDownAtArming) < -1.5f && !assume_zero_sideslip() && deltaRot < 0.1745f) {
+            // Do the first in-air yaw and earth mag field initialisation when the vehicle has gained 1.5m of altitude after arming if it is a non-fly forward vehicle (vertical takeoff)
+            // This is done to prevent magnetic field distoration from steel roofs and adjacent structures causing bad earth field and initial yaw values
+            // Do not do this alignment if the vehicle is rotating rapidly as timing erors in the mag data will cause significant errors
+            Vector3f eulerAngles;
+            getEulerAngles(eulerAngles);
+            state.quat = calcQuatAndFieldStates(eulerAngles.x, eulerAngles.y);
+            firstMagYawInit = true;
+        } else if (vehicleArmed && !secondMagYawInit && (state.position.z - posDownAtArming) < -5.0f && !assume_zero_sideslip() && deltaRot < 0.1745f) {
+            // Do the second and final yaw and earth mag field initialisation when the vehicle has gained 5.0m of altitude after arming if it is a non-fly forward vehicle (vertical takeoff)
+            // This second and final correction is needed for flight from large metal structures where the magnetic field distortion can extend up to 5m
+            // Do not do this alignment if the vehicle is rotating rapidly as timing erors in the mag data will cause significant errors
+            Vector3f eulerAngles;
+            getEulerAngles(eulerAngles);
+            state.quat = calcQuatAndFieldStates(eulerAngles.x, eulerAngles.y);
+            secondMagYawInit = true;
+        }
+
         // reset state updates and counter used to spread fusion updates across several frames to reduce 10Hz pulsing
         memset(&magIncrStateDelta[0], 0, sizeof(magIncrStateDelta));
         magUpdateCount = 0;
@@ -5038,22 +5066,6 @@ void NavEKF::performArmingChecks()
             StoreStatesReset();
         }
 
-    } else if (vehicleArmed && !firstMagYawInit && (state.position.z  - posDownAtArming) < -1.5f && !assume_zero_sideslip() && state.omega.length() < 1.0f) {
-        // Do the first in-air yaw and earth mag field initialisation when the vehicle has gained 1.5m of altitude after arming if it is a non-fly forward vehicle (vertical takeoff)
-        // This is done to prevent magnetic field distoration from steel roofs and adjacent structures causing bad earth field and initial yaw values
-        // Do not do this alignment if the vehicle is rotating rapidly as timing erors in the mag data will cause significant errors
-        Vector3f eulerAngles;
-        getEulerAngles(eulerAngles);
-        state.quat = calcQuatAndFieldStates(eulerAngles.x, eulerAngles.y);
-        firstMagYawInit = true;
-    } else if (vehicleArmed && !secondMagYawInit && (state.position.z - posDownAtArming) < -5.0f && !assume_zero_sideslip() && state.omega.length() < 1.0f) {
-        // Do the second and final yaw and earth mag field initialisation when the vehicle has gained 5.0m of altitude after arming if it is a non-fly forward vehicle (vertical takeoff)
-        // This second and final correction is needed for flight from large metal structures where the magnetic field distortion can extend up to 5m
-        // Do not do this alignment if the vehicle is rotating rapidly as timing erors in the mag data will cause significant errors
-        Vector3f eulerAngles;
-        getEulerAngles(eulerAngles);
-        state.quat = calcQuatAndFieldStates(eulerAngles.x, eulerAngles.y);
-        secondMagYawInit = true;
     }
 
     // Always turn aiding off when the vehicle is disarmed

--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -5038,16 +5038,18 @@ void NavEKF::performArmingChecks()
             StoreStatesReset();
         }
 
-    } else if (vehicleArmed && !firstMagYawInit && (state.position.z  - posDownAtArming) < -1.5f && !assume_zero_sideslip()) {
+    } else if (vehicleArmed && !firstMagYawInit && (state.position.z  - posDownAtArming) < -1.5f && !assume_zero_sideslip() && state.omega.length() < 1.0f) {
         // Do the first in-air yaw and earth mag field initialisation when the vehicle has gained 1.5m of altitude after arming if it is a non-fly forward vehicle (vertical takeoff)
         // This is done to prevent magnetic field distoration from steel roofs and adjacent structures causing bad earth field and initial yaw values
+        // Do not do this alignment if the vehicle is rotating rapidly as timing erors in the mag data will cause significant errors
         Vector3f eulerAngles;
         getEulerAngles(eulerAngles);
         state.quat = calcQuatAndFieldStates(eulerAngles.x, eulerAngles.y);
         firstMagYawInit = true;
-    } else if (vehicleArmed && !secondMagYawInit && (state.position.z - posDownAtArming) < -5.0f && !assume_zero_sideslip()) {
+    } else if (vehicleArmed && !secondMagYawInit && (state.position.z - posDownAtArming) < -5.0f && !assume_zero_sideslip() && state.omega.length() < 1.0f) {
         // Do the second and final yaw and earth mag field initialisation when the vehicle has gained 5.0m of altitude after arming if it is a non-fly forward vehicle (vertical takeoff)
         // This second and final correction is needed for flight from large metal structures where the magnetic field distortion can extend up to 5m
+        // Do not do this alignment if the vehicle is rotating rapidly as timing erors in the mag data will cause significant errors
         Vector3f eulerAngles;
         getEulerAngles(eulerAngles);
         state.quat = calcQuatAndFieldStates(eulerAngles.x, eulerAngles.y);

--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -965,7 +965,7 @@ void NavEKF::SelectMagFusion()
             // This is done to prevent magnetic field distoration from steel roofs and adjacent structures causing bad earth field and initial yaw values
             // Do not do this alignment if the vehicle is rotating rapidly as timing erors in the mag data will cause significant errors
             Vector3f eulerAngles;
-            getEulerAngles(eulerAngles);
+            statesAtMagMeasTime.quat.to_euler(eulerAngles.x, eulerAngles.y, eulerAngles.z);
             state.quat = calcQuatAndFieldStates(eulerAngles.x, eulerAngles.y);
             firstMagYawInit = true;
         } else if (vehicleArmed && !secondMagYawInit && (state.position.z - posDownAtArming) < -5.0f && !assume_zero_sideslip() && deltaRot < 0.1745f) {
@@ -973,7 +973,7 @@ void NavEKF::SelectMagFusion()
             // This second and final correction is needed for flight from large metal structures where the magnetic field distortion can extend up to 5m
             // Do not do this alignment if the vehicle is rotating rapidly as timing erors in the mag data will cause significant errors
             Vector3f eulerAngles;
-            getEulerAngles(eulerAngles);
+            statesAtMagMeasTime.quat.to_euler(eulerAngles.x, eulerAngles.y, eulerAngles.z);
             state.quat = calcQuatAndFieldStates(eulerAngles.x, eulerAngles.y);
             secondMagYawInit = true;
         }

--- a/libraries/AP_NavEKF/AP_NavEKF.h
+++ b/libraries/AP_NavEKF/AP_NavEKF.h
@@ -706,6 +706,7 @@ private:
     uint32_t lastTime_ms; // time stamp used for LPF filter applied to GPS checks
     uint32_t lastInnovPassTime_ms; // last time GPS innovation quality check passed
     uint32_t lastInnovFailTime_ms; // last time GPS innovation quality check failed
+    Quaternion prevQuatMagReset;    // Quaternion from the previous frame that the magnetic field state reset condition test was performed
 
     // Used by smoothing of state corrections
     Vector10 gpsIncrStateDelta;    // vector of corrections to attitude, velocity and position to be applied over the period between the current and next GPS measurement


### PR DESCRIPTION
High rotation rates could cause the sampling of the magnetometer to be incorrectly rotated into earth frame coordinates when performing an in-flight reset of the magnetic field states. This addresses the following JIRA issue.

https://3drsolo.atlassian.net/browse/SOLO-564