### PR TITLE
Regain EKF GPS use after prolonged loss

### DIFF
--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -4182,15 +4182,17 @@ void NavEKF::readGpsData()
         // read latitutde and longitude from GPS and convert to local NE position relative to the stored origin
         // If we don't have an origin, then set it to the current GPS coordinates
         const struct Location &gpsloc = _ahrs->get_gps().location();
-        if (validOrigin) {
+        if (validOrigin && PV_AidingMode == AID_ABSOLUTE) {
             gpsPosNE = location_diff(EKF_origin, gpsloc);
         } else if (gpsGoodToAlign){
-            // Set the NE origin to the current GPS position
-            setOrigin();
-            // Set the height of the NED origin to ‘height of baro height datum relative to GPS height datum'
-            EKF_origin.alt = gpsloc.alt - hgtMea;
-            // We are by definition at the origin at the instant of alignment so set NE position to zero
-            gpsPosNE.zero();
+            // Set the NE origin to the current GPS position if not previously set
+            if (!validOrigin) {
+                setOrigin();
+                // Set the height of the NED origin to ‘height of baro height datum relative to GPS height datum'
+                EKF_origin.alt = gpsloc.alt - hgtMea;
+                // We are by definition at the origin at the instant of alignment so set NE position to zero
+                gpsPosNE.zero();
+            }
             // If the vehicle is in flight (use arm status to determine) and GPS useage isn't explicitly prohibited, we switch to absolute position mode
             if (vehicleArmed && _fusionModeGPS != 3) {
                 constPosMode = false;


### PR DESCRIPTION
Partially addresses https://3drsolo.atlassian.net/browse/FC-292

If GPS lock is lost for an extended period of time in flight, the EKF goes into constant position mode if there is no other form of aiding (eg airspeed, optical flow etc). Current behaviour is that it will not exit from that mode when GPs is regained.

This patch allows the use of GPS to be regained using the same checks that are applied when flight is started without GPS.

The EKF origin is not changed.

This functionality has been tested in upstream SITL, however i am unable to test it in Solo SITL (cannot connect to mavproxy).