### PR TITLE
Upstream improvements for EKF

### DIFF
--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -4213,6 +4213,8 @@ void NavEKF::readGpsData()
         // Set the EKF origin and magnetic field declination if not previously set  and GPS checks have passed
         if (!validOrigin && gpsGoodToAlign) {
             setOrigin();
+            // Now we know the location we have an estimate for the magnetic field declination and adjust the earth field accordingly
+            alignMagStateDeclination();
             // Set the height of the NED origin to ‘height of baro height datum relative to GPS height datum'
             EKF_origin.alt = gpsloc.alt - hgtMea;
         }
@@ -4464,6 +4466,9 @@ Quaternion NavEKF::calcQuatAndFieldStates(float roll, float pitch)
 
         // write to earth magnetic field state vector
         state.earth_magfield = initMagNED;
+
+        // align the NE earth magnetic field states with the published declination
+        alignMagStateDeclination();
 
         // clear bad magnetometer status
         badMag = false;
@@ -5430,6 +5435,19 @@ uint32_t NavEKF::getLastYawResetAngle(float &yawAng)
 {
     yawAng = yawResetAngle;
     return lastYawReset_ms;
+}
+
+// align the NE earth magnetic field states with the published declination
+void NavEKF::alignMagStateDeclination()
+{
+    // get the magnetic declination
+    float magDecAng = use_compass() ? _ahrs->get_compass()->get_declination() : 0;
+
+    // rotate the NE values so that the declination matches the published value
+    Vector3f initMagNED = state.earth_magfield;
+    float magLengthNE = pythagorous2(initMagNED.x,initMagNED.y);
+    state.earth_magfield.x = magLengthNE * cosf(magDecAng);
+    state.earth_magfield.y = magLengthNE * sinf(magDecAng);
 }
 
 #endif // HAL_CPU_CLASS

--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -4207,29 +4207,23 @@ void NavEKF::readGpsData()
         // Monitor quality of GPS data inflight
         calcGpsGoodForFlight();
 
-        // read latitutde and longitude from GPS and convert to local NE position relative to the stored origin
-        // If we don't have an origin, then set it to the current GPS coordinates
+        // Read the GPS locaton in WGS-84 lat,long,height coordinates
         const struct Location &gpsloc = _ahrs->get_gps().location();
-        if (validOrigin && PV_AidingMode == AID_ABSOLUTE) {
-            gpsPosNE = location_diff(EKF_origin, gpsloc);
-        } else if (gpsGoodToAlign){
-            // Set the NE origin to the current GPS position if not previously set
-            if (!validOrigin) {
-                setOrigin();
-                // Set the height of the NED origin to ‘height of baro height datum relative to GPS height datum'
-                EKF_origin.alt = gpsloc.alt - hgtMea;
-                // We are by definition at the origin at the instant of alignment so set NE position to zero
-                gpsPosNE.zero();
-            }
-            // If the vehicle is in flight (use arm status to determine) and GPS useage isn't explicitly prohibited, we switch to absolute position mode
-            if (vehicleArmed && _fusionModeGPS != 3) {
-                constPosMode = false;
-                PV_AidingMode = AID_ABSOLUTE;
-                gpsNotAvailable = false;
-                // Initialise EKF position and velocity states
-                ResetPosition();
-                ResetVelocity();
-            }
+
+        // Set the EKF origin and magnetic field declination if not previously set  and GPS checks have passed
+        if (!validOrigin && gpsGoodToAlign) {
+            setOrigin();
+            // Set the height of the NED origin to ‘height of baro height datum relative to GPS height datum'
+            EKF_origin.alt = gpsloc.alt - hgtMea;
+        }
+
+        // Commence GPS aiding when able to
+        if ((_fusionModeGPS != 3) && (PV_AidingMode != AID_ABSOLUTE) && vehicleArmed && gpsGoodToAlign) {
+            PV_AidingMode = AID_ABSOLUTE;
+            constPosMode = false;
+            // Initialise EKF position and velocity states to last GPS measurement
+            ResetPosition();
+            ResetVelocity();
         }
 
         // calculate a position offset which is applied to NE position and velocity wherever it is used throughout code to allow GPS position jumps to be accommodated gradually

--- a/libraries/AP_NavEKF/AP_NavEKF.h
+++ b/libraries/AP_NavEKF/AP_NavEKF.h
@@ -464,6 +464,9 @@ private:
     // update inflight calculaton that determines if GPS data is good enough for reliable navigation
     void calcGpsGoodForFlight(void);
 
+    // align the NE earth magnetic field states with the published declination
+    void alignMagStateDeclination();
+
     // EKF Mavlink Tuneable Parameters
     AP_Float _gpsHorizVelNoise;     // GPS horizontal velocity measurement noise : m/s
     AP_Float _gpsVertVelNoise;      // GPS vertical velocity measurement noise : m/s


### PR DESCRIPTION
Timing offsets and other errors were causing the in-flight entry or re-entry into GP aiding to have transients or sometimes take two attempts after a timeout interval to achieve normal operation. This has been tested in upstream Copter SITL by flying an auto mission at 100metres altitude, disabling GPS using SIM_GPS_DISABLE=1 for 20 seconds, then re-enabling it. 

It closes a vulnerability that could allow the magnetic after an in-flight reset to be inconsistent with the published declination.

It has not been tested on Solo SITL due to problems with establishing a link to mavproxy.