### PR TITLE
Upstream improvements for EKF

### DIFF
--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -4207,29 +4207,28 @@ void NavEKF::readGpsData()
         // Monitor quality of GPS data inflight
         calcGpsGoodForFlight();
 
-        // read latitutde and longitude from GPS and convert to local NE position relative to the stored origin
-        // If we don't have an origin, then set it to the current GPS coordinates
+        // Read the GPS locaton in WGS-84 lat,long,height coordinates
         const struct Location &gpsloc = _ahrs->get_gps().location();
-        if (validOrigin && PV_AidingMode == AID_ABSOLUTE) {
+
+        // Set the EKF origin and magnetic field declination if not previously set  and GPS checks have passed
+        if (!validOrigin && gpsGoodToAlign) {
+            setOrigin();
+            // Set the height of the NED origin to ‘height of baro height datum relative to GPS height datum'
+            EKF_origin.alt = gpsloc.alt - hgtMea;
+        }
+
+        // Commence GPS aiding when able to
+        if ((_fusionModeGPS != 3) && (PV_AidingMode != AID_ABSOLUTE) && vehicleArmed && gpsGoodToAlign) {
+            PV_AidingMode = AID_ABSOLUTE;
+            constPosMode = false;
+            // Initialise EKF position and velocity states to last GPS measurement
+            ResetPosition();
+            ResetVelocity();
+        }
+
+        // Convert to local coordinates if we have an origin.
+        if (validOrigin) {
             gpsPosNE = location_diff(EKF_origin, gpsloc);
-        } else if (gpsGoodToAlign){
-            // Set the NE origin to the current GPS position if not previously set
-            if (!validOrigin) {
-                setOrigin();
-                // Set the height of the NED origin to ‘height of baro height datum relative to GPS height datum'
-                EKF_origin.alt = gpsloc.alt - hgtMea;
-                // We are by definition at the origin at the instant of alignment so set NE position to zero
-                gpsPosNE.zero();
-            }
-            // If the vehicle is in flight (use arm status to determine) and GPS useage isn't explicitly prohibited, we switch to absolute position mode
-            if (vehicleArmed && _fusionModeGPS != 3) {
-                constPosMode = false;
-                PV_AidingMode = AID_ABSOLUTE;
-                gpsNotAvailable = false;
-                // Initialise EKF position and velocity states
-                ResetPosition();
-                ResetVelocity();
-            }
         }
 
         // calculate a position offset which is applied to NE position and velocity wherever it is used throughout code to allow GPS position jumps to be accommodated gradually

--- a/libraries/AP_NavEKF/AP_NavEKF.h
+++ b/libraries/AP_NavEKF/AP_NavEKF.h
@@ -464,6 +464,9 @@ private:
     // update inflight calculaton that determines if GPS data is good enough for reliable navigation
     void calcGpsGoodForFlight(void);
 
+    // align the NE earth magnetic field states with the published declination
+    void alignMagStateDeclination();
+
     // EKF Mavlink Tuneable Parameters
     AP_Float _gpsHorizVelNoise;     // GPS horizontal velocity measurement noise : m/s
     AP_Float _gpsVertVelNoise;      // GPS vertical velocity measurement noise : m/s


### PR DESCRIPTION
This makes in-flight entry into GPS aiding more reliable and closes a vulnerability that could see a bad in-flight reset of the magnetic field result in an incorrect declination. These changes have been tested on upstream but I have been unable to test them on the Solo SITL due to an incompatibility with the mavproxy/mavlink in my build environment.