### PR TITLE
updating the diydrones path to the gcc-arm toolchain

### DIFF
--- a/Tools/scripts/install-prereqs-ubuntu.sh
+++ b/Tools/scripts/install-prereqs-ubuntu.sh
@@ -16,8 +16,8 @@ ASSUME_YES=false
 
 # GNU Tools for ARM Embedded Processors
 # (see https://launchpad.net/gcc-arm-embedded/)
-ARM_ROOT="gcc-arm-none-eabi-4_7-2014q2"
-ARM_TARBALL="$ARM_ROOT-20140408-linux.tar.bz2"
+ARM_ROOT="gcc-arm-none-eabi-4_9-2015q3"
+ARM_TARBALL="$ARM_ROOT-20150921-linux.tar.bz2"
 ARM_TARBALL_URL="http://firmware.diydrones.com/Tools/PX4-tools/$ARM_TARBALL"
 
 # Ardupilot Tools


### PR DESCRIPTION
I made a clean install in a new VM and the bash script failed to fetch the arm toolchain. The current one isn't on diydrones anymore. Updated to the one being hosted at the moment. Travis script was already updated.