### PR TITLE
travis: reduce the number of slack notifications by travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,4 +48,6 @@ deploy:
     tags: true
     all_branches: true
 notifications:
+  on_success: change
+  on_failure: change
   slack: 3dr:tT1PqGCjL6mimPYss3XRrVL7


### PR DESCRIPTION
-only reports to slack if a build status changes (on failure or success)