### PR TITLE
travis: reduce the number of slack notifications by travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,4 +48,9 @@ deploy:
     tags: true
     all_branches: true
 notifications:
-  slack: 3dr:tT1PqGCjL6mimPYss3XRrVL7
+  slack:
+    rooms:
+      - 3dr:tT1PqGCjL6mimPYss3XRrVL7
+    on_failure: change
+    on_success: change
+ 


### PR DESCRIPTION
-only reports to slack if a build status changes (on failure or success)