### PR TITLE
Fix critical bug allowing home location to be set before GPS checks passed

### DIFF
--- a/ArduCopter/commands.pde
+++ b/ArduCopter/commands.pde
@@ -39,7 +39,8 @@ static void set_home_to_current_location_inflight() {
 static bool set_home_to_current_location() {
     // get current location from EKF
     Location temp_loc;
-    if (inertial_nav.get_location(temp_loc)) {
+    nav_filter_status filt_status = inertial_nav.get_filter_status();
+    if (inertial_nav.get_location(temp_loc) && filt_status.flags.pred_horiz_pos_abs) {
         return set_home(temp_loc);
     }
     return false;


### PR DESCRIPTION
The setting of home position was not waiting for GPS checks to pass. This could result in the home position used by RTL being over 100 metres away.

Fixes bad RTL behaviour observed here https://3drsolo.atlassian.net/browse/SOLO-718