### PR TITLE
Ensure RTL to takeoff instead of startup location

### DIFF
--- a/ArduCopter/commands.pde
+++ b/ArduCopter/commands.pde
@@ -10,8 +10,8 @@
 // checks if we should update ahrs/RTL home position from the EKF
 static void update_home_from_EKF()
 {
-    // exit immediately if home already set
-    if (ap.home_state != HOME_UNSET) {
+    // exit immediately if home already set and we are flying
+    if (motors.armed() && (ap.home_state != HOME_UNSET)) {
         return;
     }
 


### PR DESCRIPTION
The home position was being set once when the EKF passed its initialisation (including GPS) checks. This meant that if the copter was started, checks passed, and then moved to a different location for flying, that RTL would return it to the start-up location, not the takeoff location.
This patch continues to update the home position while the copter is disarmed and the EKF checks are passing. This ensures that the home position will be as close as possible to the takeoff location.

Testing with the App is required to verify that the changing home location before arming has no unintended effects.