### PR TITLE
Don't use lsm303d accel data

### DIFF
--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -4177,15 +4177,19 @@ void NavEKF::readIMUData()
     // the imu sample time is used as a common time reference throughout the filter
     imuSampleTime_ms = hal.scheduler->millis();
 
-    if (ins.get_accel_health(0) && ins.get_accel_health(1)) {
-        // dual accel mode
+    if (ins.get_accel_health(0)) {
+        // use first IMU as it is less affected by vibration
         readDeltaVelocity(0, dVelIMU1, dtDelVel1);
-        readDeltaVelocity(1, dVelIMU2, dtDelVel2);
+        dtDelVel2 = dtDelVel1;
+        dVelIMU2 = dVelIMU1;
+    } else if (ins.get_accel_health(1)) {
+        // use second IMU if first not available
+        readDeltaVelocity(1, dVelIMU1, dtDelVel1);
+        dtDelVel2 = dtDelVel1;
+        dVelIMU2 = dVelIMU1;
     } else {
-        // single accel mode - one of the first two accelerometers are unhealthy
-        // read primary accelerometer into dVelIMU1 and copy to dVelIMU2
+        // If index 0 or 1 aren't avilable, then force use of the index correspinding to the primary sensor
         readDeltaVelocity(ins.get_primary_accel(), dVelIMU1, dtDelVel1);
-
         dtDelVel2 = dtDelVel1;
         dVelIMU2 = dVelIMU1;
     }


### PR DESCRIPTION
The lsm303d sensor used by IMU2 samples at a reduced rate and is noticeably more affected  by vibration at higher motor speeds than the MPU6000 sensor used by IMU1.

Here is an example of the Z accel data from the MPU6000 (green) and lsm303d (red) from a flight

![screen shot 2016-08-09 at 8 59 46 am](https://cloud.githubusercontent.com/assets/3596952/17499265/a938771a-5e0f-11e6-9d98-1b7d27c54d4f.png)

The exisiting design uses a blend of data from of each sensor with an adaptive weighting based on vertical innovations. This PR ensures that no lsm303d data will be used unless data from the MPU6000 is unavailable.

The original reason fro using blended data was to provide a universal solution that enabled the EKF to cope with aliasing due to narrow band vibration that due to the different sampling rates of the two sensors would enable the EKF to survive aliasing transients. This is not the best solution for Solo which has vibration characteristics that mostly affect the lsm303d sensor.

This relates to: https://3drsolo.atlassian.net/browse/STRIKE-47