### PR TITLE
Don't use lsm303d accel data

### DIFF
--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -2146,15 +2146,8 @@ void NavEKF::FuseVelPosNED()
                 innovVelSumSq += sq(velInnov[i]);
                 varVelSum += varInnovVelPos[i];
             }
-            // calculate weighting used by fuseVelPosNED to do IMU accel data blending
-            // this is used to detect and compensate for aliasing errors with the accelerometers
-            // provide for a first order lowpass filter to reduce noise on the weighting if required
-            // set weighting to 0.5 when on ground to allow more rapid learning of bias errors without 'ringing' in bias estimates
-            if (vehicleArmed) {
-                IMU1_weighting = 1.0f * (K1 / (K1 + K2)) + 0.0f * IMU1_weighting; // filter currently inactive
-            } else {
-                IMU1_weighting = 0.5f;
-            }
+            // Force weighting to be 100% IMU1. This is an airframe specific solution to solve problems with the airframe vibration spectra and the lsm303d sampling
+            IMU1_weighting = 1.0f;
             // apply an innovation consistency threshold test, but don't fail if bad IMU data
             // calculate the test ratio
             velTestRatio = innovVelSumSq / (varVelSum * sq(_gpsVelInnovGate));
@@ -4756,7 +4749,7 @@ void NavEKF::InitialiseVariables()
     hgtRate = 0.0f;
     mag_state.q0 = 1;
     mag_state.DCM.identity();
-    IMU1_weighting = 0.5f;
+    IMU1_weighting = 1.0f;
     onGround = true;
     manoeuvring = false;
     yawAligned = false;


### PR DESCRIPTION
The lsm303d sensor used by IMU2 samples at a reduced rate and is noticeably more affected by vibration at higher motor speeds than the MPU6000 sensor used by IMU1. This is increasing the noise in accelerations used by the land detector.

Here is an example of the Z accel data from the MPU6000 (green) and lsm303d (red) from a flight

![screen shot 2016-08-09 at 8 59 46 am](https://cloud.githubusercontent.com/assets/3596952/17499884/0763b2ba-5e14-11e6-895a-010cf277c4e4.png)

The exisiting design uses a blend of data from of each sensor with an adaptive weighting based on vertical innovations. This PR ensures that no lsm303d data will be used unless data from the MPU6000 is unavailable.

The original reason fro using blended data was to provide a universal solution that enabled the EKF to cope with aliasing due to narrow band vibration that due to the different sampling rates of the two sensors would enable the EKF to survive aliasing transients. This is not the best solution for Solo which has vibration characteristics that mostly affect the lsm303d sensor.

This relates to: https://3drsolo.atlassian.net/browse/STRIKE-47