### PR TITLE
Do not block flight code or perform IMU calibration when arming

### DIFF
--- a/ArduCopter/ArduCopter.pde
+++ b/ArduCopter/ArduCopter.pde
@@ -641,6 +641,10 @@ static uint32_t rtl_loiter_start_time;
 // Used to exit the roll and pitch auto trim function
 static uint8_t auto_trim_counter;
 
+// Used to delay motor arming/start from when the request to arm was approved
+static uint32_t motor_arm_approved_time_ms = 0;
+static bool motor_arm_pending = false;
+
 // Reference to the relay object
 static AP_Relay relay;
 


### PR DESCRIPTION
Addresses https://3drsolo.atlassian.net/browse/IG-1355

Movement of the copter on loose surfaces can cause the calibration to fail and prevent takeoff/.
The calibration is not required because the EKF learns gyro biases after power up.
The calibration is blocking and will cause errors in the inertial nav solution if the vehicle changes orientation during arming.

This PR removes the arming gyro cal and also makes the delay from arming to motor start non-blocking