### PR TITLE
R10C Gimbal presence detect + message gating

### DIFF
--- a/ArduCopter/GCS_Mavlink.pde
+++ b/ArduCopter/GCS_Mavlink.pde
@@ -1066,14 +1066,8 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
 
     case MAVLINK_MSG_ID_R10C_GIMBAL_REPORT:
     {
-        static int32_t last_received;
 #if MOUNT==ENABLED
-        mavlink_r10c_gimbal_report_t r10c_report;
-        mavlink_msg_r10c_gimbal_report_decode(msg, &r10c_report);
-        float pitch_ref = (float)r10c_report.pitch_ref/(1<<22);
-        float roll_out = (float)r10c_report.roll_out/(1<<22);
-        float pitch_out = (float)r10c_report.pitch_out/(1<<22);
-        DataFlash.Log_Write_R10CGimbal(pitch_ref, roll_out, pitch_out, r10c_report.roll_pwm, r10c_report.pitch_pwm);
+        handle_r10c_gimbal_report(camera_mount, msg);
 #endif
         break;
     }

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -666,6 +666,16 @@ void AP_Mount::handle_gimbal_torque_report(mavlink_channel_t chan, mavlink_messa
     }    
 }
 
+// pass an R10C_GIMBAL_REPORT message to the backend
+void AP_Mount::handle_r10c_gimbal_report(mavlink_channel_t chan, mavlink_message_t *msg)
+{
+    for (uint8_t instance=0; instance<AP_MOUNT_MAX_INSTANCES; instance++) {
+        if (_backends[instance] != NULL) {
+            _backends[instance]->handle_r10c_gimbal_report(chan, msg);
+        }
+    }
+}
+
 // send a GIMBAL_REPORT message to the GCS
 void AP_Mount::send_gimbal_report(mavlink_channel_t chan)
 {

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -124,6 +124,7 @@ public:
     // handle a GIMBAL_REPORT message
     void handle_gimbal_report(mavlink_channel_t chan, mavlink_message_t *msg);
     void handle_gimbal_torque_report(mavlink_channel_t chan, mavlink_message_t *msg);
+    void handle_r10c_gimbal_report(mavlink_channel_t chan, mavlink_message_t *msg);
 
     // send a GIMBAL_REPORT message to GCS
     void send_gimbal_report(mavlink_channel_t chan);

--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -74,6 +74,7 @@ public:
     // handle a GIMBAL_REPORT message
     virtual void handle_gimbal_report(mavlink_channel_t chan, mavlink_message_t *msg) {}
     virtual void handle_gimbal_torque_report(mavlink_channel_t chan, mavlink_message_t *msg) {}
+    virtual void handle_r10c_gimbal_report(mavlink_channel_t chan, mavlink_message_t *msg) {}
 
     // send a GIMBAL_REPORT message to the GCS
     virtual void send_gimbal_report(mavlink_channel_t chan) {}

--- a/libraries/AP_Mount/AP_Mount_R10C.h
+++ b/libraries/AP_Mount/AP_Mount_R10C.h
@@ -15,12 +15,18 @@
 #include <RC_Channel_aux.h>
 #include "AP_Mount_Backend.h"
 
+enum r10c_gimbal_state_t {
+    R10C_GIMBAL_STATE_NOT_PRESENT = 0,
+    R10C_GIMBAL_STATE_PRESENT_RUNNING
+};
+
 class AP_Mount_R10C : public AP_Mount_Backend
 {
 public:
     // Constructor
     AP_Mount_R10C(AP_Mount &frontend, AP_Mount::mount_state &state, uint8_t instance):
         AP_Mount_Backend(frontend, state, instance),
+        _r10c_state(R10C_GIMBAL_STATE_NOT_PRESENT),
         _roll_idx(RC_Channel_aux::k_none),
         _tilt_idx(RC_Channel_aux::k_none),
         _pan_idx(RC_Channel_aux::k_none),
@@ -50,7 +56,13 @@ public:
     // status_msg - called to allow mounts to send their status to GCS using the MOUNT_STATUS message
     virtual void status_msg(mavlink_channel_t chan);
 
+    bool present();
+
+    // handle an R10C_GIMBAL_REPORT message
+    void handle_r10c_gimbal_report(mavlink_channel_t chan, mavlink_message_t *msg);
+
 private:
+    r10c_gimbal_state_t _r10c_state;
 
     // flags structure
     struct {
@@ -81,6 +93,8 @@ private:
     Vector3f _angle_bf_output_deg;  // final body frame output angle in degrees
 
     uint32_t _last_check_servo_map_ms;  // system time of latest call to check_servo_map function
+
+    uint32_t _last_report_msg_ms;
 };
 
 #endif // __AP_Mount_R10C_H__

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -307,6 +307,7 @@ private:
     void handle_set_mode(mavlink_message_t* msg, bool (*set_mode)(uint8_t mode));
     void handle_gimbal_report(AP_Mount &mount, mavlink_message_t *msg) const;
     void handle_gimbal_torque_report(AP_Mount &mount, mavlink_message_t *msg) const;
+    void handle_r10c_gimbal_report(AP_Mount &mount, mavlink_message_t *msg) const;
 
     void handle_gps_inject(const mavlink_message_t *msg, AP_GPS &gps);
 

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -414,6 +414,15 @@ void GCS_MAVLINK::handle_gimbal_torque_report(AP_Mount &mount, mavlink_message_t
 {
     mount.handle_gimbal_torque_report(chan,msg);
 }
+
+/*
+  handle r10c gimbal report
+*/
+void GCS_MAVLINK::handle_r10c_gimbal_report(AP_Mount &mount, mavlink_message_t *msg) const
+{
+    mount.handle_r10c_gimbal_report(chan,msg);
+}
+
 /*
   return true if a channel has flow control
  */


### PR DESCRIPTION
This stops the attitude messages from being sent to the R10C gimbal when it's not in a ready state, which is determined by the receipt of the R10C report messages.

Relates to https://3drsolo.atlassian.net/browse/IG-1250