### PR TITLE
slow down home position update

### DIFF
--- a/ArduCopter/ArduCopter.pde
+++ b/ArduCopter/ArduCopter.pde
@@ -1113,6 +1113,9 @@ static void one_hz_loop()
 
     gcs_send_message(MSG_ARMMASK);
 
+    // update home location from EKF if necessary
+    update_home_from_EKF();
+    
     if (!motors.armed()) {
         // make it possible to change ahrs orientation at runtime during initial config
         ahrs.set_orientation();

--- a/ArduCopter/ArduCopter.pde
+++ b/ArduCopter/ArduCopter.pde
@@ -893,7 +893,7 @@ void loop()
 }
 
 
-// Main loop - 100hz
+// Main loop - 400hz
 static void fast_loop()
 {
 
@@ -920,9 +920,6 @@ static void fast_loop()
 
     // run the attitude controllers
     update_flight_mode();
-
-    // update home from EKF if necessary
-    update_home_from_EKF();
 
     // check if we've landed or crashed
     update_land_and_crash_detectors();

--- a/ArduCopter/navigation.pde
+++ b/ArduCopter/navigation.pde
@@ -8,6 +8,9 @@ static void run_nav_updates(void)
     // fetch position from inertial navigation
     calc_position();
 
+    // update home location from EKF if necessary
+    update_home_from_EKF();
+    
     // calculate distance and bearing for reporting and autopilot decisions
     calc_distance_and_bearing();
 

--- a/ArduCopter/navigation.pde
+++ b/ArduCopter/navigation.pde
@@ -8,9 +8,6 @@ static void run_nav_updates(void)
     // fetch position from inertial navigation
     calc_position();
 
-    // update home location from EKF if necessary
-    update_home_from_EKF();
-    
     // calculate distance and bearing for reporting and autopilot decisions
     calc_distance_and_bearing();
 


### PR DESCRIPTION
HOME_POSITION message is 52 data bytes * 400 hz = 20.8kB/sec increase in UART traffic (ignoring overhead). Suspect that this causing failures in dronekit connectivity.

This PR moves the home position update method to a 50 hz scheduled function, resulting in around 2.6kB/sec increase in UART traffic. Confirmed in telem_forwarder logs that the downstream  byte count changes by roughly this amount depending on arming state as desired.