### PR TITLE
Land detector logging

### DIFF
--- a/ArduCopter/ArduCopter.pde
+++ b/ArduCopter/ArduCopter.pde
@@ -1030,6 +1030,7 @@ static void ten_hz_logging_loop()
     if (should_log(MASK_LOG_NTUN) && (mode_requires_GPS(control_mode) || landing_with_GPS())) {
         Log_Write_Nav_Tuning();
     }
+    Log_Write_Land_Detector();
 }
 
 // fifty_hz_logging_loop

--- a/ArduCopter/Log.pde
+++ b/ArduCopter/Log.pde
@@ -620,6 +620,28 @@ static void Log_Write_Parameter_Tuning(uint8_t param, float tuning_val, int16_t 
     DataFlash.WriteBlock(&pkt_tune, sizeof(pkt_tune));
 }
 
+struct PACKED log_LandDetector {
+    LOG_PACKET_HEADER;
+    uint32_t time_ms;
+    float land_accel_ef_x;
+    float land_accel_ef_y;
+    float land_accel_ef_z;
+};
+
+static void Log_Write_Land_Detector()
+{
+    const Vector3f land_accel_ef = land_accel_ef_filter.get();
+    struct log_LandDetector pkt_land = {
+        LOG_PACKET_HEADER_INIT(LOG_LANDDETECT_MSG),
+        time_ms           : hal.scheduler->millis(),
+        land_accel_ef_x   : land_accel_ef.x,
+        land_accel_ef_y   : land_accel_ef.y,
+        land_accel_ef_z   : land_accel_ef.z
+    };
+    
+    DataFlash.WriteBlock(&pkt_land, sizeof(pkt_land));
+}
+
 static const struct LogStructure log_structure[] PROGMEM = {
     LOG_COMMON_STRUCTURES,
 #if AUTOTUNE_ENABLED == ENABLED
@@ -642,6 +664,8 @@ static const struct LogStructure log_structure[] PROGMEM = {
       "RATE", "Iffffffffffff",  "TimeMS,RDes,R,ROut,PDes,P,POut,YDes,Y,YOut,ADes,A,AOut" },
     { LOG_MOTBATT_MSG, sizeof(log_MotBatt),
       "MOTB", "Iffff",  "TimeMS,LiftMax,BatVolt,BatRes,ThLimit" },
+    { LOG_LANDDETECT_MSG, sizeof(log_LandDetector),
+      "LAND", "Ifff", "TimeMS,LandAccX,LandAccY,LandAccZ" },
     { LOG_STARTUP_MSG, sizeof(log_Startup),         
       "STRT", "",            "" },
     { LOG_EVENT_MSG, sizeof(log_Event),         

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -413,7 +413,7 @@
  # define LAND_DETECTOR_MAYBE_TRIGGER_SEC   0.2f    // number of seconds that means we might be landed (used to reset horizontal position targets to prevent tipping over)
 #endif
 #ifndef LAND_DETECTOR_ACCEL_LPF_CUTOFF
-# define LAND_DETECTOR_ACCEL_LPF_CUTOFF     1.0f    // frequency cutoff of land detector accelerometer filter
+# define LAND_DETECTOR_ACCEL_LPF_CUTOFF     5.0f    // frequency cutoff of land detector accelerometer filter
 #endif
 #ifndef LAND_DETECTOR_ACCEL_MAX
 # define LAND_DETECTOR_ACCEL_MAX            1.0f    // vehicle acceleration must be under 1m/s/s

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -247,6 +247,7 @@ enum FlipState {
 #define LOG_RATE_MSG                    0x1D
 #define LOG_MOTBATT_MSG                 0x1E
 #define LOG_PARAMTUNE_MSG               0x1F
+#define LOG_LANDDETECT_MSG              0x20
 
 #define MASK_LOG_ATTITUDE_FAST          (1<<0)
 #define MASK_LOG_ATTITUDE_MED           (1<<1)


### PR DESCRIPTION
1) Add logging of the filtered acceleration used to trip the land detector
2) Increases the cutoff frequency of the LPF for those accel to 5Hz (from 3Hz) to give us a better idea of the noise spectrum