### PR TITLE
Remove timeout/retry logic on mavlink mount detection

### DIFF
--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -451,14 +451,14 @@ void AP_Mount::update(uint8_t mount_compid,  AP_SerialManager& serial_manager)
 {
 #if AP_AHRS_NAVEKF_AVAILABLE
     static AP_HAL::UARTDriver *uart = serial_manager.find_serial(AP_SerialManager::SerialProtocol_MAVLink,1);
-    static bool begin_gmb_uart;
-    static uint32_t baud = serial_manager.find_baudrate(AP_SerialManager::SerialProtocol_MAVLink,1);
+    //static bool begin_gmb_uart;
+    //static uint32_t baud = serial_manager.find_baudrate(AP_SerialManager::SerialProtocol_MAVLink,1);
     for (uint8_t instance=0; instance<AP_MOUNT_MAX_INSTANCES; instance++) {
-
+        /*
         if(_retries > MAX_RETRIES) { //no mavlink gimbal found
             break;
         }
-
+        */
         MountType mount_type = get_mount_type(instance);
         // check for MAVLink mounts
         if (mount_type == Mount_Type_MAVLink && !_mav_gimbal_found) {
@@ -479,6 +479,9 @@ void AP_Mount::update(uint8_t mount_compid,  AP_SerialManager& serial_manager)
                     _primary = instance;
                     primary_set = true;
                 }
+            }
+        }
+        /*
             } else if(_timeout) {
                 //change baud rate of gimbal port and retry
                 if(baud == 921600) {
@@ -511,6 +514,7 @@ void AP_Mount::update(uint8_t mount_compid,  AP_SerialManager& serial_manager)
                 _timeout = ((hal.scheduler->millis() - _last_time)>=5000) ? true : false;
             }
         }
+        */
     }
 #endif
     // update each instance

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -446,19 +446,12 @@ void AP_Mount::init(DataFlash_Class *dataflash, const AP_SerialManager& serial_m
 }
 
 // update - give mount opportunity to update servos.  should be called at 10hz or higher
-// update - give mount opportunity to update servos.  should be called at 10hz or higher
 void AP_Mount::update(uint8_t mount_compid,  AP_SerialManager& serial_manager)
 {
 #if AP_AHRS_NAVEKF_AVAILABLE
     static AP_HAL::UARTDriver *uart = serial_manager.find_serial(AP_SerialManager::SerialProtocol_MAVLink,1);
-    //static bool begin_gmb_uart;
-    //static uint32_t baud = serial_manager.find_baudrate(AP_SerialManager::SerialProtocol_MAVLink,1);
+
     for (uint8_t instance=0; instance<AP_MOUNT_MAX_INSTANCES; instance++) {
-        /*
-        if(_retries > MAX_RETRIES) { //no mavlink gimbal found
-            break;
-        }
-        */
         MountType mount_type = get_mount_type(instance);
         // check for MAVLink mounts
         if (mount_type == Mount_Type_MAVLink && !_mav_gimbal_found) {
@@ -481,40 +474,6 @@ void AP_Mount::update(uint8_t mount_compid,  AP_SerialManager& serial_manager)
                 }
             }
         }
-        /*
-            } else if(_timeout) {
-                //change baud rate of gimbal port and retry
-                if(baud == 921600) {
-                    hal.console->printf("Looking for R10C Gimbal!!\n");
-                    uart->end();
-                    baud = 230400;
-                } else if(baud == 230400) {
-                    hal.console->printf("Looking for Solo Gimbal!!\n");
-                    uart->end();
-                    baud = 921600;
-                } else {
-                    hal.console->printf("Setting Back to Default Baud: %d!!\n", 921600);
-                    uart->end();
-                    baud = 921600;
-                }
-
-                _timeout = false;
-                begin_gmb_uart = true;
-                _last_time = hal.scheduler->millis();
-                _retries++;
-                if(_retries == MAX_RETRIES) {
-                    hal.console->printf("No MavLink Gimbal Found!!\n");
-                }
-            } else {
-                if(begin_gmb_uart && ((hal.scheduler->millis() - _last_time)>=1000)) {
-                    uart->begin(baud);
-                    hal.console->printf("Setting Gimbal port baud to %d\n", baud);
-                    begin_gmb_uart = false;
-                }
-                _timeout = ((hal.scheduler->millis() - _last_time)>=5000) ? true : false;
-            }
-        }
-        */
     }
 #endif
     // update each instance


### PR DESCRIPTION
This removes the last vestiges of the logic put in place to handle the different baud rates of the Solo gimbal and Qbert. Now that these baud rates are the same, the logic is removed along with some unnecessary timeouts.