### PR TITLE
Allow operation from a surface with large magnetic anomaly

### DIFF
--- a/ArduCopter/ArduCopter.pde
+++ b/ArduCopter/ArduCopter.pde
@@ -638,6 +638,12 @@ static uint16_t mainLoop_count;
 // Loiter timer - Records how long we have been in loiter
 static uint32_t rtl_loiter_start_time;
 
+// last time in msec that the pre-arm compass consistency check failed
+static uint32_t last_mag_fail_time_ms = 0;
+
+// last time in msec that the pre-arm compass consistency check passed
+static uint32_t last_mag_pass_time_ms = 0;
+
 // Used to exit the roll and pitch auto trim function
 static uint8_t auto_trim_counter;
 

--- a/ArduCopter/motors.pde
+++ b/ArduCopter/motors.pde
@@ -303,10 +303,20 @@ static bool pre_arm_checks(bool display_failure)
             return false;
         }
 
+        // Check that the different magnetometers are providing consistent data
+        // Latch the check to passsed if 3 continuous seconds of pass occurs
+        // This allows the user to pick up the copter to clear the failure if it is caused by a ground level magnetic anomaly
         if (!compass.consistent()) {
+            last_mag_fail_time_ms = millis();
+        } else {
+            last_mag_pass_time_ms = millis();
+        }
+        bool mag_consistency_failed = (last_mag_pass_time_ms == 0 || (millis() - last_mag_fail_time_ms) <= 3000);
+        if (mag_consistency_failed) {
             if (display_failure) {
                 gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: inconsistent compasses"));
             }
+            last_mag_fail_time_ms = millis();
             return false;
         }
     }

--- a/ArduCopter/motors.pde
+++ b/ArduCopter/motors.pde
@@ -311,12 +311,11 @@ static bool pre_arm_checks(bool display_failure)
         } else {
             last_mag_pass_time_ms = millis();
         }
-        bool mag_consistency_failed = (last_mag_pass_time_ms == 0 || (millis() - last_mag_fail_time_ms) <= 3000);
-        if (mag_consistency_failed) {
+        bool mag_consistency_passed = (last_mag_pass_time_ms != 0 && (millis() - last_mag_fail_time_ms) > 3000);
+        if (!mag_consistency_passed) {
             if (display_failure) {
                 gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: inconsistent compasses"));
             }
-            last_mag_fail_time_ms = millis();
             return false;
         }
     }


### PR DESCRIPTION
This patch allows the compass consistency check to latch to a passed condition if 3 seconds of continuous pass is recorded.
This allows the user to clear a failing compass consistency check by picking up the vehicle and putting it down again.

Partially addresses https://3drsolo.atlassian.net/browse/IG-1350

Requires the user to perform an action to clear which requires changes to the app.