### PR TITLE
Make Qbert the only supported Mavlink mount

### DIFF
--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -155,7 +155,6 @@ protected:
 
     // mavlink detect vars
     uint8_t             _retries;
-    bool                _mav_gimbal_found;
     bool                primary_set = false;
     uint32_t            _last_time;
     bool                _timeout;


### PR DESCRIPTION
There was an observed issue where occasionally the mount_compid detected by the GCS_Mavlink.pde heartbeat handler is somehow set to MAV_COMP_ID_GIMBAL, even though the heartbeat coming from Qbert is sent with MAV_COMP_ID_R10C_GIMBAL. This event triggered the instantiation of a SoloGimbal mount object, which is incompatible with Qbert.

Open questions: where was that heartbeat coming from?????
