### PR TITLE
gps_glitch: wait for position_ok before consider GPS glitch cleared

### DIFF
--- a/ArduCopter/gps_glitch.pde
+++ b/ArduCopter/gps_glitch.pde
@@ -5,7 +5,7 @@ static void gps_glitch_update() {
 
     if (glitch && !failsafe.gps_glitch) {
         gps_glitch_on_event();
-    } else if (!glitch && failsafe.gps_glitch) {
+    } else if (!glitch && failsafe.gps_glitch && position_ok()) {
         gps_glitch_off_event();
     }
 }


### PR DESCRIPTION
* Prevents a race condition between the EKF position check and the gps glitch logic from occurring.
* This race condition would manifest itself by preventing a mode change into LOITER after resolving a GPS glitch.