### PR TITLE
gps_glitch: clear gps_glitch_switch_mode_on_resolve flag after resolving

### DIFF
--- a/ArduCopter/gps_glitch.pde
+++ b/ArduCopter/gps_glitch.pde
@@ -33,5 +33,6 @@ static void gps_glitch_off_event() {
 
     if (gps_glitch_switch_mode_on_resolve) {
         set_mode(LOITER);
+        gps_glitch_switch_mode_on_resolve = false;
     }
 }


### PR DESCRIPTION
* this fixes issues where multiple glitches on a single flight could lead to erroneously entering LOITER as a failsafe behavior