### PR TITLE
Add air pressure lower limit to pre-arm checks

### DIFF
--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -139,7 +139,8 @@ public:
         k_param_altitude_limit,         // deprecated - remove
         k_param_fence,
         k_param_gps_glitch,             // deprecated
-        k_param_baro_glitch,            // 71 - deprecated
+        k_param_baro_glitch,            // deprecated
+        k_param_baro_launch_limit,   // 72
 
         //
         // 75: Singlecopter, CoaxCopter
@@ -361,6 +362,9 @@ public:
     AP_Int16        throttle_behavior;
     AP_Int16        takeoff_trigger_dz;
     AP_Float        pilot_takeoff_alt;
+
+    // takeoff environmental limits
+    AP_Float        baro_launch_limit;      // If the barometric pressure is lower than this value, the copter will not arm - Pa
 
     // Thrust loss recovery
     //

--- a/ArduCopter/Parameters.pde
+++ b/ArduCopter/Parameters.pde
@@ -1096,6 +1096,15 @@ const AP_Param::Info var_info[] PROGMEM = {
     // @User: Standard
     GSCALAR(autotune_aggressiveness, "AUTOTUNE_AGGR", 0.1f),
 
+    // @Param: GND_PRESS_MIN
+    // @DisplayName: ground level air pressure minimum
+    // @Description: If the ground level air pressure is lower than this value, then the copter will not arm. This is used to prevent takeoff at high elevaton locations where air density is insuffient for safe flight.
+    // @Units: Pa
+    // @Range: 50000 80000
+    // @Increment: 1000
+    // @User: Advanced
+    GSCALAR(baro_launch_limit, "GND_PRESS_MIN", 80000.0f),
+
     AP_VAREND
 };
 

--- a/ArduCopter/motors.pde
+++ b/ArduCopter/motors.pde
@@ -252,6 +252,13 @@ static bool pre_arm_checks(bool display_failure)
             }
             return false;
         }
+        // check that we are below our launch service ceiling
+        if( barometer.get_pressure() < g.baro_launch_limit ) {
+            if (display_failure) {
+                gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: Launch ceiling exceeded"));
+            }
+            return false;
+        }
         // Check baro & inav alt are within 1m if EKF is operating in an absolute position mode.
         // Do not check if intending to operate in a ground relative height mode as EKF will output a ground relative height
         // that may differ from the baro height due to baro drift.


### PR DESCRIPTION
Addresses https://3drsolo.atlassian.net/browse/IG-1549

Enables an adjustable minimum value of air pressure to be set to prevent operation at excessive field elevation. Has been tested by setting the parameter to the just larger than the measured air pressure to verify that pre-arm checks fail.

When the check fails the following MAVLink error message is output:

APM: PreArm: Launch ceiling exceeded