### PR TITLE
Copter: Prevent localised magnetic anomaly failing pre-arm checks

### DIFF
--- a/ArduCopter/ArduCopter.pde
+++ b/ArduCopter/ArduCopter.pde
@@ -658,6 +658,15 @@ static uint32_t last_mag_pass_time_ms = 0;
 // true when the pre-arm compass consistency check has passed for long enough to latch
 static bool mag_pass_latched = false;
 
+// last time in msec that the pre-arm field strength check failed
+static uint32_t last_field_fail_time_ms = 0;
+
+// last time in msec that the pre-arm field strength check passed
+static uint32_t last_field_pass_time_ms = 0;
+
+// true when the pre-arm field strength check has passed for long enough to latch
+static bool field_pass_latched = false;
+
 // Used to exit the roll and pitch auto trim function
 static uint8_t auto_trim_counter;
 


### PR DESCRIPTION
Enables lifting the copter away from the source of magnetic interference to get consistent compasses for 3 seconds so that the strength check can pass.

Addresses: https://3drsolo.atlassian.net/projects/IG/issues/IG-1619