### PR TITLE
Allow in-flight yaw and mag field alignment for repeated takeoffs from magnetic surfaces

### DIFF
--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -4529,6 +4529,12 @@ Quaternion NavEKF::calcQuatAndFieldStates(float roll, float pitch)
         yawAligned = false;
     }
 
+    if (!vehicleArmed) {
+        // The flags indicating that the in-air alignment has been completed need to be cleared
+        // because this alignment is on-ground and the yaw and field values could be incorrect.
+        secondMagYawInit = firstMagYawInit = false;
+    }
+
     // return attitude quaternion
     return initQuat;
 }


### PR DESCRIPTION
Addresses: https://3drsolo.atlassian.net/browse/IG-1637

Landing on a surface with a magnetic anomaly large enough to require the EKF to reset its field states can result in poor heading and large EKF magnetometer and velocity innovations if the vehicle is re-armed and takes off. This happens because the flags indicating that completion of the in-air yaw and field states was not being reset if a ground reset had occurred.
This patch ensures that any reset of magnetic field states that occurs whilst disarmed causes the flags to be reset.