### PR TITLE
Enable selection of preferred IMU EKF for gyro data

### DIFF
--- a/libraries/AP_NavEKF/AP_NavEKF.h
+++ b/libraries/AP_NavEKF/AP_NavEKF.h
@@ -524,6 +524,7 @@ private:
     AP_Float _gpsPosDriftLim;       // Maximum measured GPS horizontal position drift rate allowed during pre-flight checks (m/s)
     AP_Float _gpsVertSpdLim;        // Maximum measured GPS vertical speed allowed during pre-flight checks (m/s)
     AP_Float _gpsHorizSpdLim;       // Maximum measured GPS horizontal speed allowed during pre-flight checks (m/s)
+    AP_Int8 _gyroSelect;            // Selects the IMU gyros used. 0 = use blend of IMU1 and IMU2, 1 = force use IMU1, 2 = force use IMU2
 
     // Tuning parameters
     const float gpsNEVelVarAccScale;    // Scale factor applied to NE velocity measurement variance due to manoeuvre acceleration


### PR DESCRIPTION
https://3drsolo.atlassian.net/browse/IG-1678

This PR adds a parameter EKF_GYR_SELECT which enables which IMU's will be used by the EKF. The default value of 0 uses both which is the same as previous behaviour. A value of 1 will use IMU1 only and a value of 2 will use IMU2 only. Any other value will use both. If the selected IMU is unhealthy, then it will revert to  the primary/healthy sensor.

It has been bench tested and has had a short flight in stabilise.
