### PR TITLE
Copter: Ensure land_init is called for every use of the land controller

### DIFF
--- a/ArduCopter/control_auto.pde
+++ b/ArduCopter/control_auto.pde
@@ -265,6 +265,9 @@ static void auto_land_start(const Vector3f& destination)
 {
     auto_mode = Auto_Land;
 
+    // Setup land controller
+    land_init(false);
+
     // initialise loiter target destination
     wp_nav.init_loiter_target(destination);
 

--- a/ArduCopter/control_land.pde
+++ b/ArduCopter/control_land.pde
@@ -228,8 +228,9 @@ static float get_land_descent_speed()
     if (pos_control.get_pos_target().z >= pv_alt_above_origin(LAND_START_ALT) && !(sonar_ok && sonar_alt_health >= SONAR_ALT_HEALTH_MAX)) {
         // if we are within the land ramp profile
         if (land_ramp && pos_control.get_pos_target().z <= land_ramp_xi){
-            return -fabsf(land_ramp_vi + (land_ramp_vf-land_ramp_vi)*(pos_control.get_pos_target().z-land_ramp_xi)/(land_ramp_xf-land_ramp_xi));
+            return -constrain_float(fabsf(land_ramp_vi + (land_ramp_vf-land_ramp_vi)*(pos_control.get_pos_target().z-land_ramp_xi)/(land_ramp_xf-land_ramp_xi)), land_ramp_vf, land_ramp_vi);
         }else{
+            // note: returns a negative value
             return pos_control.get_speed_down();
         }
     // if we're below LAND_START_ALT, use land_speed

--- a/ArduCopter/control_rtl.pde
+++ b/ArduCopter/control_rtl.pde
@@ -303,6 +303,9 @@ static void rtl_land_start()
     rtl_state = Land;
     rtl_state_complete = false;
 
+    // Setup land controller
+    land_init(false);
+
     // Set wp navigation target to above home
     wp_nav.init_loiter_target(wp_nav.get_wp_destination());
 


### PR DESCRIPTION
The land_init() initializes speed ramp variables. This function was only being called by LAND mode but not AUTO or RTL modes (which utilizes land controller methods). If the static variables are not set explicitly then the landing ramp is disabled. However, if they were set in a previous landing without power cycle and the EKF has reset, then the static variables set in land_init are stale and must be recalculated.