### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Ardupilot Solo
+# Ardupilot Solo
 
 [![Build Status](https://travis-ci.org/3drobotics/ardupilot-solo.svg?branch=master)](https://travis-ci.org/3drobotics/ardupilot-solo)
 
@@ -24,7 +24,7 @@
 
 ---
 
-#ArduPilot Project#
+# ArduPilot Project #
 
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/diydrones/ardupilot?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 

--- a/Tools/Linux_HAL_Essentials/README.md
+++ b/Tools/Linux_HAL_Essentials/README.md
@@ -1,7 +1,7 @@
 PRU PWM
 =======
 
-###Updating kernel
+### Updating kernel
 * Check your kernel version using `uname -r`
 * If you get 3.8.13bone56+ as output then you may skip Updating kernel.
 * For other kernel versions write following cmds in your BBB:
@@ -19,7 +19,7 @@ NOTE: For Ubuntu different scripts shall be used. E.g., for precise:
 
 ----
 
-###Setting Up PRU Compiler
+### Setting Up PRU Compiler
 * Download [PRU C Compiler v2.0.0B2 installer](http://software-dl.ti.com/codegen/non-esd/downloads/beta.htm)
 * Please check the path where you install PRU compiler.
 * Setting environment variable
@@ -31,7 +31,7 @@ source ~/.bashrc
 
 *note: semicolons in second command were intended*
 
-###Compiling and loading the code
+### Compiling and loading the code
 * just `make`
 * copy generated executable `pwmpru1` to `ardupilot/Tools/Linux_HAL_Essentials/`.
 * To load firmware use 

--- a/Tools/Linux_HAL_Essentials/devicetree/bbbmini/README.md
+++ b/Tools/Linux_HAL_Essentials/devicetree/bbbmini/README.md
@@ -1,4 +1,4 @@
-#Hardware
+# Hardware
 
 ## Load device tree
 To load the BBBMINI device tree type `startup.sh load`.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
