### PR TITLE
If changing mode to LOITER fails, fallback to ALT_HOLD

### DIFF
--- a/ArduCopter/flight_mode.pde
+++ b/ArduCopter/flight_mode.pde
@@ -52,6 +52,11 @@ static bool set_mode(uint8_t mode)
 
         case LOITER:
             success = loiter_init(ignore_checks);
+            // If we cannot enter loiter mode for any reason (it happens to be because we don't have a good position estimate)
+            // Fallback to althold
+            if (!success) {
+                success = althold_init(ignore_checks);
+            }
             break;
 
         case GUIDED:


### PR DESCRIPTION
We've seen a case where the drone entered `failsafe.GPS_GLITCH` state and remained in GUIDED mode. They tried to take manual control by changing mode to LOITER. The system refused to enter the LOITER mode, because of the GPS_GLITCH failsafe state. 

This PR introduces a fallback mechanism where it attempts to enter ALT_HOLD mode after a failed attempt to enter LOITER mode.