### PR TITLE
After a GPS_GLITCH without RC control, set mode to LAND. 

### DIFF
--- a/ArduCopter/control_land.pde
+++ b/ArduCopter/control_land.pde
@@ -16,7 +16,7 @@ static bool land_ramp;
 static bool land_init(bool ignore_checks)
 {
     // check if we have GPS and decide which LAND we're going to do
-    land_with_gps = position_ok();
+    land_with_gps = position_ok() && !failsafe.gps_glitch;
     if (land_with_gps) {
         // set target to stopping point
         Vector3f stopping_point;

--- a/ArduCopter/gps_glitch.pde
+++ b/ArduCopter/gps_glitch.pde
@@ -14,9 +14,15 @@ static void gps_glitch_on_event() {
     failsafe.gps_glitch = true;
     Log_Write_Error(ERROR_SUBSYSTEM_FAILSAFE_GPS, ERROR_CODE_FAILSAFE_OCCURRED);
 
-    if (motors.armed() && mode_requires_RC(control_mode) && mode_requires_GPS(control_mode) && !failsafe.radio && !failsafe.ekf) {
-        if(set_mode(ALT_HOLD)) {
-            gps_glitch_switch_mode_on_resolve = true;
+    if (motors.armed() && mode_requires_GPS(control_mode) && !failsafe.radio && !failsafe.ekf) {
+        if (mode_requires_RC(control_mode)) {
+            if(set_mode(ALT_HOLD)) {
+                gps_glitch_switch_mode_on_resolve = true;
+            }
+        } else {
+            if(set_mode(LAND)) {
+                gps_glitch_switch_mode_on_resolve = true;
+            }
         }
     }
 }


### PR DESCRIPTION
There are two classes of GPS failsafe: failsafe.GPS_GLITCH and failsafe.EKF, in increasing order of severity. This deals with the former. The logic described below was first introduced in Ardupilot-Solo v1.4.0 and applies only to Site Scan, which has a significantly reduced set of operating conditions compared to Ardupilot more generally.

If Solo is in a flight mode (i.e. LOITER), that requires stick control and close operator attention, a GPS_GLITCH failsafe triggers a switch to ALT_HOLD. This behaviour is preserved.

If the user is in a flight mode (i.e GUIDED) that does not require stick control, it is not safe to assume that the operator will be paying close attention. Previously the behaviour was to do nothing until the GPS failsafe escalated to EKF. This was based on the assumption that GUIDED mode flight generally takes place far away from obstacles, and so a relatively minor and brief degradation in position accuracy is "less bad" than the consequences of completely giving up on position control and switching to a non-GPS flight mode.

This assumption has been called into question after a recent event where a user managed to take off in GUIDED mode with a damaged compass. (The compass failed after passing pre-flight checks and before takeoff). In this case, a GPS_GLITCH occurred immediately after takeoff, at which point remaining in GUIDED mode allowed for erratic flight at low altitude that would have been avoided had the drone switched into a non-GPS flight mode.

The dataflash flight log is available upon a reviewer's request.

This PR changes the GPS_GLITCH failsafe functionality so that if such an event occurs and the current mode does not require stick control (i.e. GUIDED), the mode is changed to non-GPS-assisted-LAND. If the failsafe condition escalates to EKF, the drone will continue to land without GPS. If the failsafe condition clears, the mode will change to loiter, and the drone will hover in place until commanded to move either by user action or a battery failsafe.